### PR TITLE
[feat] AOP 기반 로깅 및 전역 예외 처리, 공통 응답 구조 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,9 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// AOP
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/hotsix/server/ServerApplication.java
+++ b/src/main/java/com/hotsix/server/ServerApplication.java
@@ -2,8 +2,10 @@ package com.hotsix.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class ServerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/hotsix/server/global/aop/LoggingAspect.java
+++ b/src/main/java/com/hotsix/server/global/aop/LoggingAspect.java
@@ -1,5 +1,7 @@
 package com.hotsix.server.global.aop;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.After;
@@ -7,6 +9,11 @@ import org.aspectj.lang.annotation.AfterThrowing;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
 import org.springframework.stereotype.Component;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Aspect
@@ -34,5 +41,23 @@ public class LoggingAspect {
                 joinPoint.getSignature().getDeclaringTypeName(),
                 joinPoint.getSignature().getName(),
                 ex.getMessage(), ex);
+    }
+
+    private String safeArgs(JoinPoint jp) {
+        Object[] args = jp.getArgs();
+        if (args == null || args.length == 0) return "[]";
+        return Arrays.stream(args)
+                .map(this::safeValue)
+                .collect(Collectors.joining(", ", "[", "]"));
+    }
+
+    private String safeValue(Object v) {
+        if (v == null) return "null";
+        if (v instanceof MultipartFile f) return "MultipartFile(size=" + f.getSize() + ")";
+        if (v instanceof byte[] b) return "byte[](" + b.length + ")";
+        if (v instanceof HttpServletRequest) return "HttpServletRequest";
+        if (v instanceof HttpServletResponse) return "HttpServletResponse";
+        if (v instanceof BindingResult br) return "BindingResult(errors=" + br.getErrorCount() + ")";
+        return String.valueOf(v);
     }
 }

--- a/src/main/java/com/hotsix/server/global/aop/LoggingAspect.java
+++ b/src/main/java/com/hotsix/server/global/aop/LoggingAspect.java
@@ -1,0 +1,38 @@
+package com.hotsix.server.global.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.After;
+import org.aspectj.lang.annotation.AfterThrowing;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Component
+public class LoggingAspect {
+
+    @Before("execution(* com.hotsix.server..service..*(..))")
+    public void logBefore(JoinPoint joinPoint) {
+        log.info("[START] {}.{}() args = {}",
+                joinPoint.getSignature().getDeclaringTypeName(),
+                joinPoint.getSignature().getName(),
+                joinPoint.getArgs());
+    }
+
+    @After("execution(* com.hotsix.server..service..*(..))")
+    public void logAfter(JoinPoint joinPoint) {
+        log.info("[ END ] {}.{}()",
+                joinPoint.getSignature().getDeclaringTypeName(),
+                joinPoint.getSignature().getName());
+    }
+
+    @AfterThrowing(pointcut = "execution(* com.hotsix.server..service..*(..))", throwing = "ex")
+    public void logException(JoinPoint joinPoint, Throwable ex) {
+        log.error("[ERROR] {}.{}() => {}",
+                joinPoint.getSignature().getDeclaringTypeName(),
+                joinPoint.getSignature().getName(),
+                ex.getMessage(), ex);
+    }
+}

--- a/src/main/java/com/hotsix/server/global/exception/ApplicationException.java
+++ b/src/main/java/com/hotsix/server/global/exception/ApplicationException.java
@@ -1,0 +1,14 @@
+package com.hotsix.server.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ApplicationException extends RuntimeException {
+
+    private final ErrorCase errorCase;
+
+    public ApplicationException(ErrorCase errorCase) {
+        super(errorCase.getMessage());
+        this.errorCase = errorCase;
+    }
+}

--- a/src/main/java/com/hotsix/server/global/exception/ErrorCase.java
+++ b/src/main/java/com/hotsix/server/global/exception/ErrorCase.java
@@ -1,0 +1,10 @@
+package com.hotsix.server.global.exception;
+
+public interface ErrorCase {
+
+    Integer getHttpStatusCode();
+
+    Integer getErrorCode();
+
+    String getMessage();
+}

--- a/src/main/java/com/hotsix/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/hotsix/server/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,45 @@
+package com.hotsix.server.global.exception;
+
+import com.hotsix.server.global.response.CommonResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ApplicationException.class)
+    public ResponseEntity<CommonResponse<?>> handleApplicationException(ApplicationException e) {
+        CommonResponse<?> response = CommonResponse.error(e.getErrorCase());
+        return ResponseEntity
+                .status(e.getErrorCase().getHttpStatusCode())
+                .body(response);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<CommonResponse<?>> handleValidException(MethodArgumentNotValidException ex) {
+        String message = ex.getBindingResult()
+                .getAllErrors()
+                .stream()
+                .findFirst()
+                .map(ObjectError::getDefaultMessage)
+                .orElse("유효성 검사 실패: 잘못된 요청입니다.");
+
+        CommonResponse<?> response = CommonResponse.error(400, message);
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(response);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<CommonResponse<?>> handleUnexpectedException(Exception ex) {
+        log.error("[UnexpectedException] {}", ex.getMessage(), ex);
+        CommonResponse<?> response = CommonResponse.error(500, "서버 내부 오류가 발생했습니다.");
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+    }
+}

--- a/src/main/java/com/hotsix/server/global/response/CommonResponse.java
+++ b/src/main/java/com/hotsix/server/global/response/CommonResponse.java
@@ -1,0 +1,42 @@
+package com.hotsix.server.global.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.hotsix.server.global.exception.ErrorCase;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CommonResponse<T> {
+
+    private Integer errorCode;
+    private String message;
+    private T data;
+
+    public static <T> CommonResponse<T> success(T data) {
+        return CommonResponse.<T>builder()
+                .data(data)
+                .build();
+    }
+
+    public static CommonResponse<Object> success() {
+        return CommonResponse.builder()
+                .message("success")
+                .build();
+    }
+
+    public static <T> CommonResponse<T> error(ErrorCase errorCase) {
+        return CommonResponse.<T>builder()
+                .errorCode(errorCase.getErrorCode())
+                .message(errorCase.getMessage())
+                .build();
+    }
+
+    public static <T> CommonResponse<T> error(Integer errorCode, String message) {
+        return CommonResponse.<T>builder()
+                .errorCode(errorCode)
+                .message(message)
+                .build();
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #4 

## 📝 작업 내용

**1. AOP 기반 서비스 로깅 기능**
- 서비스 계층의 메서드 실행 시 로그 출력

**2. 전역 예외 처리**
- 공통 예외 처리용 핸들러 구성
- 예외 처리 지원:
- ApplicationException: 커스텀 예외 처리
- MethodArgumentNotValidException: 유효성 검사 실패 시 메시지 추출
- Exception: 기타 예외 관련

**3. 커스텀 예외 클래스**

**4. 예외 상세 정보 관련**
- 각 예외마다 HTTP 상태 코드, 커스텀 에러 코드, 메시지

**5. 공통 응답 포맷 클래스**
- 모든 API 응답을 일관된 구조로 반환하도록 설정
- 성공: { "data": ... }
- 실패: { "errorCode": ..., "message": ... }

**6. AOP 의존성 및 JPA audition 추가** 
## 🖼️ 스크린샷 (선택)

> UI 변경 등 시각적으로 확인할 수 있는 내용이 있다면 첨부해주세요

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요