### PR TITLE
[feat] Redis 및 Docker 개발 환경 구성 , Redis 저장,조회 관련 테스트코드 작성 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ out/
 
 ### application.yml ###
 application.yml
+application-docker.yml
 
 ### .env ###
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ out/
 
 ### application.yml ###
 application.yml
+
+### .env ###
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM openjdk:21-jdk-slim
+
+RUN apt-get update && \
+    apt-get install -y wget && \
+    wget -O /usr/local/bin/wait-for-it.sh https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh && \
+    chmod +x /usr/local/bin/wait-for-it.sh
+
+WORKDIR /app
+
+COPY build/libs/server-0.0.1-SNAPSHOT.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["/usr/local/bin/wait-for-it.sh", "redis:6379", "--timeout=30", "--", "java", "-jar", "app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
 
 WORKDIR /app
 
-COPY build/libs/server-0.0.1-SNAPSHOT.jar app.jar
+COPY build/libs/hotsix-0.0.1-SNAPSHOT.jar app.jar
 
 EXPOSE 8080
 

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,10 @@ dependencies {
 
 	// MySQL
 	runtimeOnly 'com.mysql:mysql-connector-j:8.3.0'
+
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3.8'
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: hotsix-app
+    ports:
+      - "8080:8080"
+    depends_on:
+      - redis
+    environment:
+      SPRING_PROFILES_ACTIVE: docker
+      SPRING_DATA_REDIS_HOST: redis
+      SPRING_DATA_REDIS_PORT: 6379
+      SPRING_DATA_REDIS_PASSWORD: ${REDIS_DEV_PASSWORD}
+      TZ: Asia/Seoul
+    restart: always
+    volumes:
+      - ./logs:/app/logs
+
+  redis:
+    image: redis:7.2
+    container_name: hotsix-redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    command: ["redis-server", "--requirepass", "${REDIS_DEV_PASSWORD}"]
+    restart: always
+
+volumes:
+  redis-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,16 +9,22 @@ services:
     ports:
       - "8080:8080"
     depends_on:
-      - redis
+      redis:
+        condition: service_healthy
     environment:
       SPRING_PROFILES_ACTIVE: docker
       SPRING_DATA_REDIS_HOST: redis
       SPRING_DATA_REDIS_PORT: 6379
       SPRING_DATA_REDIS_PASSWORD: ${REDIS_DEV_PASSWORD}
       TZ: Asia/Seoul
-    restart: always
+    restart: on-failure  # 운영용: restart: always
     volumes:
       - ./logs:/app/logs
+    healthcheck:
+      test: [ "CMD", "redis-cli", "--raw", "incr", "ping" ]
+      interval: 10s
+      timeout: 3s
+      retries: 5
 
   redis:
     image: redis:7.2
@@ -28,7 +34,12 @@ services:
     volumes:
       - redis-data:/data
     command: ["redis-server", "--requirepass", "${REDIS_DEV_PASSWORD}"]
-    restart: always
+    restart: on-failure  # 운영용: restart: always
+    healthcheck:
+      test: [ "CMD", "redis-cli", "-a", "${REDIS_DEV_PASSWORD}", "ping" ]
+      interval: 10s
+      timeout: 3s
+      retries: 5
 
 volumes:
   redis-data:

--- a/src/main/java/com/hotsix/server/auth/entity/RefreshToken.java
+++ b/src/main/java/com/hotsix/server/auth/entity/RefreshToken.java
@@ -3,13 +3,15 @@ package com.hotsix.server.auth.entity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.io.Serializable;
+
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 @Table(name = "refresh_token")
-public class RefreshToken {
+public class RefreshToken implements Serializable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/hotsix/server/global/config/RedisConfig.java
+++ b/src/main/java/com/hotsix/server/global/config/RedisConfig.java
@@ -1,0 +1,50 @@
+package com.hotsix.server.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.util.StringUtils;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.password:}")
+    private String password;
+
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
+        if (StringUtils.hasText(password)) {
+            config.setPassword(password);
+        }
+        return new LettuceConnectionFactory(config);
+    }
+
+    @Bean
+    @Primary
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        return template;
+    }
+}

--- a/src/test/java/com/hotsix/server/redis/RedisTemplateTest.java
+++ b/src/test/java/com/hotsix/server/redis/RedisTemplateTest.java
@@ -1,0 +1,41 @@
+package com.hotsix.server.redis;
+
+import com.hotsix.server.auth.entity.RefreshToken;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+class RedisTemplateTest {
+
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Test
+    @DisplayName("Redis refreshtoken 저장,조회 테스트")
+    void redis_refreshToken_test() {
+        String key = "refreshToken:1";
+        RefreshToken token = RefreshToken.builder()
+                .id(1L)
+                .userId(1L)
+                .token("abc.def.ghi")
+                .expiry(System.currentTimeMillis() + 3600000) // 1시간 후
+                .build();
+
+        redisTemplate.opsForValue().set(key, token);
+
+        Object value = redisTemplate.opsForValue().get(key);
+        assertThat(value).isInstanceOf(RefreshToken.class);
+
+        RefreshToken retrieved = (RefreshToken) value;
+        assertThat(retrieved.getUserId()).isEqualTo(1L);
+        assertThat(retrieved.getToken()).isEqualTo("abc.def.ghi");
+
+        System.out.println("Redis 저장된 RefreshToken 확인: " + retrieved);
+
+        redisTemplate.delete(key);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #10 , #13 

## 📝 작업 내용

**1. Docker 기반 개발 환경 구성**
- Dockerfile 및 docker-compose.yml 구현

**2. Redis 설정 클래스(RedisConfig) 추가**

**3. Redis 연동 테스트 코드 작성 (확인 완료)**

- RefreshToken 객체를 Redis에 저장하고 다시 조회하는 테스트코드 구현



## 🖼️ 스크린샷 (선택)

> UI 변경 등 시각적으로 확인할 수 있는 내용이 있다면 첨부해주세요

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - Redis 연동 설정 및 클라이언트 템플릿 추가로 키-값 저장소(예: 토큰/캐시) 활용 가능.
  - Dockerfile 및 docker-compose 추가로 앱+Redis 컨테이너 실행, 포트 노출, 로그 마운트, 재시작 및 환경변수/프로파일 관리 지원.

- 테스트
  - Redis에 RefreshToken 저장·조회 동작을 검증하는 통합 테스트 추가.

- 잡무
  - .gitignore 업데이트(.env 및 Docker 관련 항목 추가).
  - 빌드 의존성에 Redis 및 JSON 처리 라이브러리 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->