### PR TITLE
[feat] 프로젝트 등록,상태변경, 특정 프로젝트에 달린 리뷰 조회 API 구현 

### DIFF
--- a/src/main/java/com/hotsix/server/project/controller/ProjectController.java
+++ b/src/main/java/com/hotsix/server/project/controller/ProjectController.java
@@ -34,4 +34,6 @@ public class ProjectController {
     ) {
         return CommonResponse.success(projectService.registerProject(userId, dto));
     }
+
+    // TODO: 프로젝트 상세 조회 API 개발 (GET)
 }

--- a/src/main/java/com/hotsix/server/project/controller/ProjectController.java
+++ b/src/main/java/com/hotsix/server/project/controller/ProjectController.java
@@ -1,12 +1,37 @@
 package com.hotsix.server.project.controller;
 
 
+import com.hotsix.server.auth.resolver.CurrentUser;
+import com.hotsix.server.global.response.CommonResponse;
+import com.hotsix.server.project.dto.ProjectRequestDto;
+import com.hotsix.server.project.dto.ProjectResponseDto;
+import com.hotsix.server.project.service.ProjectService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/projects")
 @RequiredArgsConstructor
 public class ProjectController {
+
+    private final ProjectService projectService;
+
+    @PostMapping
+    @Operation(summary = "프로젝트 등록", description = "클라이언트와 프리랜서가 원하는 프로젝트를 등록합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "프로젝트 등록 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    public CommonResponse<ProjectResponseDto> registerProject(
+            @Parameter(hidden = true) @CurrentUser Long userId,
+            @RequestBody @Valid ProjectRequestDto dto
+    ) {
+        return CommonResponse.success(projectService.registerProject(userId, dto));
+    }
 }

--- a/src/main/java/com/hotsix/server/project/controller/ProjectController.java
+++ b/src/main/java/com/hotsix/server/project/controller/ProjectController.java
@@ -5,6 +5,7 @@ import com.hotsix.server.auth.resolver.CurrentUser;
 import com.hotsix.server.global.response.CommonResponse;
 import com.hotsix.server.project.dto.ProjectRequestDto;
 import com.hotsix.server.project.dto.ProjectResponseDto;
+import com.hotsix.server.project.dto.ProjectStatusUpdateRequestDto;
 import com.hotsix.server.project.service.ProjectService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -33,6 +34,23 @@ public class ProjectController {
             @RequestBody @Valid ProjectRequestDto dto
     ) {
         return CommonResponse.success(projectService.registerProject(userId, dto));
+    }
+
+    @PatchMapping("/{projectId}/status")
+    @Operation(summary = "프로젝트 상태 변경", description = "프로젝트의 상태를 변경합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "상태 변경 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "권한 없음"),
+            @ApiResponse(responseCode = "404", description = "프로젝트를 찾을 수 없음")
+    })
+    public CommonResponse<ProjectResponseDto> updateProjectStatus(
+            @Parameter(hidden = true) @CurrentUser Long userId,
+            @PathVariable Long projectId,
+            @RequestBody @Valid ProjectStatusUpdateRequestDto dto
+    ) {
+        return CommonResponse.success(projectService.updateProjectStatus(userId, projectId, dto));
     }
 
     // TODO: 프로젝트 상세 조회 API 개발 (GET)

--- a/src/main/java/com/hotsix/server/project/dto/ProjectRequestDto.java
+++ b/src/main/java/com/hotsix/server/project/dto/ProjectRequestDto.java
@@ -1,0 +1,25 @@
+package com.hotsix.server.project.dto;
+
+import jakarta.validation.constraints.*;
+import java.time.LocalDate;
+
+public record ProjectRequestDto(
+        @NotNull(message = "상대방 유저 ID는 필수입니다.")
+        Long targetUserId,   // 상대방 유저 ID (클라이언트면 프리랜서 ID, 프리랜서면 클라이언트 ID)
+
+        @NotBlank(message = "프로젝트 제목은 필수입니다.")
+        String title,
+
+        @NotBlank(message = "프로젝트 설명은 필수입니다.")
+        String description,
+
+        @NotNull(message = "예산은 필수입니다.")
+        @Positive(message = "예산은 양수여야 합니다.")
+        Integer budget,
+
+        @NotNull(message = "마감일은 필수입니다.")
+        LocalDate deadline,
+
+        @NotBlank(message = "카테고리는 필수입니다.")
+        String category
+) {}

--- a/src/main/java/com/hotsix/server/project/dto/ProjectResponseDto.java
+++ b/src/main/java/com/hotsix/server/project/dto/ProjectResponseDto.java
@@ -1,0 +1,15 @@
+package com.hotsix.server.project.dto;
+
+import java.time.LocalDate;
+
+public record ProjectResponseDto(
+        Long projectId,
+        String clientNickname,
+        String freelancerNickname,
+        String title,
+        String description,
+        Integer budget,
+        LocalDate deadline,
+        String category,
+        String status
+) {}

--- a/src/main/java/com/hotsix/server/project/dto/ProjectStatusUpdateRequestDto.java
+++ b/src/main/java/com/hotsix/server/project/dto/ProjectStatusUpdateRequestDto.java
@@ -1,0 +1,10 @@
+package com.hotsix.server.project.dto;
+
+import com.hotsix.server.project.entity.Status;
+import jakarta.validation.constraints.NotNull;
+
+// 프로젝트의 상태를 변경하기 위한 DTO (OPEN, IN_PROGRESS, COMPLETED 관련)
+public record ProjectStatusUpdateRequestDto(
+        @NotNull(message = "변경할 상태를 입력해주세요.")
+        Status status
+) {}

--- a/src/main/java/com/hotsix/server/project/entity/Project.java
+++ b/src/main/java/com/hotsix/server/project/entity/Project.java
@@ -38,4 +38,8 @@ public class Project extends BaseEntity {
     private Status status; // OPEN, IN_PROGRESS, COMPLETED
 
     private String category;
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/com/hotsix/server/project/exception/ProjectErrorCase.java
+++ b/src/main/java/com/hotsix/server/project/exception/ProjectErrorCase.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ProjectErrorCase implements ErrorCase {
 
-    PROJECT_NOT_FOUND(404, 3001, "프로젝트를 찾을 수 없습니다.");
+    PROJECT_NOT_FOUND(404, 3001, "프로젝트를 찾을 수 없습니다."),
+    NO_PERMISSION(403, 3002, "해당 프로젝트에 대한 권한이 없습니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/hotsix/server/project/service/ProjectService.java
+++ b/src/main/java/com/hotsix/server/project/service/ProjectService.java
@@ -2,8 +2,74 @@ package com.hotsix.server.project.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import com.hotsix.server.global.exception.ApplicationException;
+import com.hotsix.server.project.dto.ProjectRequestDto;
+import com.hotsix.server.project.dto.ProjectResponseDto;
+import com.hotsix.server.project.entity.Project;
+import com.hotsix.server.project.entity.Status;
+import com.hotsix.server.project.repository.ProjectRepository;
+import com.hotsix.server.user.entity.Role;
+import com.hotsix.server.user.entity.User;
+import com.hotsix.server.user.exception.UserErrorCase;
+import com.hotsix.server.user.repository.UserRepository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class ProjectService {
+
+    private final ProjectRepository projectRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public ProjectResponseDto registerProject(Long currentUserId, ProjectRequestDto dto) {
+        User currentUser = userRepository.findById(currentUserId)
+                .orElseThrow(() -> new ApplicationException(UserErrorCase.EMAIL_NOT_FOUND));
+
+        User targetUser = userRepository.findById(dto.targetUserId())
+                .orElseThrow(() -> new ApplicationException(UserErrorCase.EMAIL_NOT_FOUND));
+
+        Project project;
+
+        // 프로젝트 등록은 클라이언트,프리랜서 둘다 가능하도록 (회원가입 한 Role에 따라 clientId,freelancerId로 구분)
+        if (currentUser.getRole() == Role.CLIENT) {
+            // 현재 유저가 클라이언트면 → 상대방은 프리랜서
+            project = Project.builder()
+                    .client(currentUser)
+                    .freelancer(targetUser)
+                    .title(dto.title())
+                    .description(dto.description())
+                    .budget(dto.budget())
+                    .deadline(dto.deadline())
+                    .status(Status.OPEN)
+                    .category(dto.category())
+                    .build();
+        } else {
+            // 현재 유저가 프리랜서면 → 상대방은 클라이언트
+            project = Project.builder()
+                    .client(targetUser)
+                    .freelancer(currentUser)
+                    .title(dto.title())
+                    .description(dto.description())
+                    .budget(dto.budget())
+                    .deadline(dto.deadline())
+                    .status(Status.OPEN)
+                    .category(dto.category())
+                    .build();
+        }
+
+        Project saved = projectRepository.save(project);
+
+        return new ProjectResponseDto(
+                saved.getProjectId(),
+                saved.getClient().getNickname(),
+                saved.getFreelancer().getNickname(),
+                saved.getTitle(),
+                saved.getDescription(),
+                saved.getBudget(),
+                saved.getDeadline(),
+                saved.getCategory(),
+                saved.getStatus().name()
+        );
+    }
 }

--- a/src/main/java/com/hotsix/server/project/service/ProjectService.java
+++ b/src/main/java/com/hotsix/server/project/service/ProjectService.java
@@ -1,5 +1,7 @@
 package com.hotsix.server.project.service;
 
+import com.hotsix.server.project.dto.ProjectStatusUpdateRequestDto;
+import com.hotsix.server.project.exception.ProjectErrorCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import com.hotsix.server.global.exception.ApplicationException;
@@ -75,6 +77,33 @@ public class ProjectService {
                 saved.getDeadline(),
                 saved.getCategory(),
                 saved.getStatus().name()
+        );
+    }
+
+    @Transactional
+    public ProjectResponseDto updateProjectStatus(Long userId, Long projectId, ProjectStatusUpdateRequestDto dto) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new ApplicationException(ProjectErrorCase.PROJECT_NOT_FOUND));
+
+        // 권한 체크: client 또는 freelancer인 경우만 수정 가능
+        if (!project.getClient().getUserId().equals(userId) &&
+                !project.getFreelancer().getUserId().equals(userId)) {
+            throw new ApplicationException(ProjectErrorCase.NO_PERMISSION);
+        }
+
+        // 상태 변경
+        project.setStatus(dto.status());
+
+        return new ProjectResponseDto(
+                project.getProjectId(),
+                project.getClient().getNickname(),
+                project.getFreelancer().getNickname(),
+                project.getTitle(),
+                project.getDescription(),
+                project.getBudget(),
+                project.getDeadline(),
+                project.getCategory(),
+                project.getStatus().name()
         );
     }
 }

--- a/src/main/java/com/hotsix/server/proposal/entity/Contract.java
+++ b/src/main/java/com/hotsix/server/proposal/entity/Contract.java
@@ -26,6 +26,5 @@ public class Contract extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private ContractStatus contractStatus; // DRAFT, REVIEW, COMPLETED, TERMINATED, CANCELLED
-
-
 }
+

--- a/src/main/java/com/hotsix/server/review/controller/ReviewController.java
+++ b/src/main/java/com/hotsix/server/review/controller/ReviewController.java
@@ -60,4 +60,16 @@ public class ReviewController {
     ) {
         return CommonResponse.success(reviewService.getReviewsWrittenByUser(userId));
     }
+
+    @GetMapping("/project/{projectId}")
+    @Operation(summary = "프로젝트에 달린 리뷰 목록 조회", description = "특정 프로젝트에 작성된 모든 리뷰를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "프로젝트를 찾을 수 없음")
+    })
+    public CommonResponse<List<ReviewResponseDto>> getReviewsByProject(
+            @PathVariable Long projectId
+    ) {
+        return CommonResponse.success(reviewService.getReviewsByProject(projectId));
+    }
 }

--- a/src/main/java/com/hotsix/server/review/repository/ReviewRepository.java
+++ b/src/main/java/com/hotsix/server/review/repository/ReviewRepository.java
@@ -10,4 +10,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     List<Review> findAllByFromUser_UserId(Long fromUserId);
 
     boolean existsByProject_ProjectIdAndFromUser_UserId(Long projectId, Long fromUserId);
+
+    List<Review> findAllByProject_ProjectId(Long projectId);
 }

--- a/src/main/java/com/hotsix/server/review/service/ReviewService.java
+++ b/src/main/java/com/hotsix/server/review/service/ReviewService.java
@@ -91,4 +91,23 @@ public class ReviewService {
         }
         throw new ApplicationException(ReviewErrorCase.UNAUTHORIZED_REVIEWER);
     }
+
+    @Transactional(readOnly = true)
+    public List<ReviewResponseDto> getReviewsByProject(Long projectId) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new ApplicationException(ReviewErrorCase.PROJECT_NOT_FOUND));
+
+        return reviewRepository.findAllByProject_ProjectId(projectId).stream()
+                .map(review -> new ReviewResponseDto(
+                        review.getReviewId(),
+                        review.getFromUser().getNickname(),
+                        review.getRating(),
+                        review.getComment(),
+                        review.getCreatedAt().toLocalDate(),
+                        review.getReviewImageList().stream()
+                                .map(ReviewImage::getImageUrl)
+                                .collect(Collectors.toList())
+                ))
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/hotsix/server/review/service/ReviewService.java
+++ b/src/main/java/com/hotsix/server/review/service/ReviewService.java
@@ -84,11 +84,11 @@ public class ReviewService {
     // 프로젝트와 작성자를 기반으로 리뷰 대상 결정
     private User getTargetUser(Project project, User writer) {
         if (project.getClient().equals(writer)) {
-                        return project.getFreelancer();
-                    }
-                if (project.getFreelancer().equals(writer)) {
-                        return project.getClient();
-                    }
-                throw new ApplicationException(ReviewErrorCase.UNAUTHORIZED_REVIEWER);
+            return project.getFreelancer();
+        }
+        if (project.getFreelancer().equals(writer)) {
+            return project.getClient();
+        }
+        throw new ApplicationException(ReviewErrorCase.UNAUTHORIZED_REVIEWER);
     }
 }

--- a/src/test/java/com/hotsix/server/redis/RedisTemplateTest.java
+++ b/src/test/java/com/hotsix/server/redis/RedisTemplateTest.java
@@ -1,41 +1,45 @@
-//package com.hotsix.server.redis;
-//
-//import com.hotsix.server.auth.entity.RefreshToken;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.boot.test.context.SpringBootTest;
-//import org.springframework.data.redis.core.RedisTemplate;
-//import static org.assertj.core.api.Assertions.*;
-//
-//@SpringBootTest
-//class RedisTemplateTest {
-//
-//    @Autowired
-//    private RedisTemplate<String, Object> redisTemplate;
-//
-//    @Test
-//    @DisplayName("Redis refreshtoken 저장,조회 테스트")
-//    void redis_refreshToken_test() {
-//        String key = "refreshToken:1";
-//        RefreshToken token = RefreshToken.builder()
-//                .id(1L)
-//                .userId(1L)
-//                .token("abc.def.ghi")
-//                .expiry(System.currentTimeMillis() + 3600000) // 1시간 후
-//                .build();
-//
-//        redisTemplate.opsForValue().set(key, token);
-//
-//        Object value = redisTemplate.opsForValue().get(key);
-//        assertThat(value).isInstanceOf(RefreshToken.class);
-//
-//        RefreshToken retrieved = (RefreshToken) value;
-//        assertThat(retrieved.getUserId()).isEqualTo(1L);
-//        assertThat(retrieved.getToken()).isEqualTo("abc.def.ghi");
-//
-//        System.out.println("Redis 저장된 RefreshToken 확인: " + retrieved);
-//
-//        redisTemplate.delete(key);
-//    }
-//}
+/*
+package com.hotsix.server.redis;
+
+import com.hotsix.server.auth.entity.RefreshToken;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DataRedisTest
+@ActiveProfiles("test")
+class RedisTemplateTest {
+
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Test
+    @DisplayName("Redis refreshtoken 저장,조회 테스트")
+    void redis_refreshToken_test() {
+        String key = "refreshToken:1";
+        RefreshToken token = RefreshToken.builder()
+                .id(1L)
+                .userId(1L)
+                .token("abc.def.ghi")
+                .expiry(System.currentTimeMillis() + 3600000) // 1시간 후
+                .build();
+
+        redisTemplate.opsForValue().set(key, token);
+
+        Object value = redisTemplate.opsForValue().get(key);        assertThat(value).isInstanceOf(RefreshToken.class);
+
+        RefreshToken retrieved = (RefreshToken) value;
+        assertThat(retrieved.getUserId()).isEqualTo(1L);
+        assertThat(retrieved.getToken()).isEqualTo("abc.def.ghi");
+
+        System.out.println("Redis 저장된 RefreshToken 확인: " + retrieved);
+
+        redisTemplate.delete(key);
+    }
+}
+ */


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #23 

## 📝 작업 내용
**1. 프로젝트 상태 변경 API 추가**
- PATCH (/api/v1/projects/{projectId}/status)
- 프론트엔드에서 버튼 클릭 시 프로젝트 상태를 OPEN, IN_PROGRESS, COMPLETED 등으로 변경 할 수 있도록 API 구현 


**2. 프로젝트 등록 API 구현** 
- POST (/api/v1/projects)
- 사용자가 원하는 프로젝트에 대해서 등록 할 수 있도록 기능 구현 (프리랜서,클라이언트 둘다 등록 가능)

**3. 특정 프로젝트의 리뷰 목록 조회 API 추가**
- GET (/api/v1/reviews/project/{projectId})
- 특정 프로젝트에 작성된 모든 리뷰를 리스트로 반환
- 리뷰 작성자 닉네임, 평점, 코멘트, 작성일, 이미지 리스트 포함

**4. 리뷰 등록, 내가 적은 리뷰 조회 API 관련 테스트**
- 프로젝트 등록 및 상태 변경 API 추가에 따라 리뷰 관련 API 스웨거 테스트 포함

## 🖼️ 스크린샷 (선택)
### 프로젝트 등록 성공
<img width="1469" height="947" alt="프로젝트등록성공" src="https://github.com/user-attachments/assets/cdce7bbd-5e9c-49a2-b02c-b314c9890d63" />

### 프로젝트 상태 변경
<img width="1464" height="949" alt="프로젝트상태변경성공" src="https://github.com/user-attachments/assets/de9a34eb-d676-4dde-99a8-4608a2e2b029" />

### 리뷰 등록 성공
<img width="1459" height="946" alt="리뷰등록성공" src="https://github.com/user-attachments/assets/29a39a6a-2a99-4a94-bf18-4529a6f11a91" />

### 내가 쓴 리뷰 목록 조회 성공 
<img width="1468" height="942" alt="리뷰목록조회성공" src="https://github.com/user-attachments/assets/6682353d-1816-4fd1-b9a0-dbca6dd28b45" />

### 특정 프로젝트의 리뷰 목록 조회 성공
<img width="1450" height="941" alt="화면 캡처 2025-10-02 123318" src="https://github.com/user-attachments/assets/ed11aadb-7873-47b5-b35f-ab9c721487cb" />


## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요