### PR TITLE
[test] 프로젝트 등록, 상태 변경 관련 서비스,컨트롤러 로직 테스트코드 구현 

### DIFF
--- a/src/test/java/com/hotsix/server/project/controller/ProjectControllerTest.java
+++ b/src/test/java/com/hotsix/server/project/controller/ProjectControllerTest.java
@@ -1,0 +1,139 @@
+package com.hotsix.server.project.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.hotsix.server.auth.resolver.CurrentUserArgumentResolver;
+import com.hotsix.server.project.dto.ProjectRequestDto;
+import com.hotsix.server.project.dto.ProjectResponseDto;
+import com.hotsix.server.project.dto.ProjectStatusUpdateRequestDto;
+import com.hotsix.server.project.entity.Status;
+import com.hotsix.server.project.service.ProjectService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.core.MethodParameter;
+
+import java.time.LocalDate;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+@ActiveProfiles("test")
+class ProjectControllerTest {
+
+    private MockMvc mockMvc;
+    private ProjectService projectService;
+    private CurrentUserArgumentResolver currentUserArgumentResolver;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        projectService = Mockito.mock(ProjectService.class);
+        currentUserArgumentResolver = Mockito.mock(CurrentUserArgumentResolver.class);
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+
+        ProjectController controller = new ProjectController(projectService);
+
+        this.mockMvc = MockMvcBuilders
+                .standaloneSetup(controller)
+                .setCustomArgumentResolvers(currentUserArgumentResolver)
+                .build();
+    }
+
+    @Test
+    @DisplayName("프로젝트 등록 성공")
+    void registerProjectSuccess() throws Exception {
+        Long userId = 1L;
+        Long targetUserId = 2L;
+
+        ProjectRequestDto requestDto = new ProjectRequestDto(
+                targetUserId, "프로젝트명", "설명", 1000, LocalDate.now().plusDays(7), "IT"
+        );
+
+        ProjectResponseDto responseDto = new ProjectResponseDto(
+                1L, "클라이언트", "프리랜서", "프로젝트명", "설명", 1000, LocalDate.now().plusDays(7), "IT", "OPEN"
+        );
+
+        when(currentUserArgumentResolver.supportsParameter(any(MethodParameter.class))).thenReturn(true);
+        when(currentUserArgumentResolver.resolveArgument(any(), any(), any(), any())).thenReturn(userId);
+        when(projectService.registerProject(eq(userId), any(ProjectRequestDto.class))).thenReturn(responseDto);
+
+        mockMvc.perform(post("/api/v1/projects")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.projectId").value(1L))
+                .andExpect(jsonPath("$.data.title").value("프로젝트명"));
+    }
+
+    @Test
+    @DisplayName("프로젝트 상태 변경 성공")
+    void updateProjectStatusSuccess() throws Exception {
+        Long userId = 1L;
+        Long projectId = 10L;
+
+        ProjectStatusUpdateRequestDto requestDto = new ProjectStatusUpdateRequestDto(Status.COMPLETED);
+
+        ProjectResponseDto responseDto = new ProjectResponseDto(
+                projectId, "클라이언트", "프리랜서", "프로젝트명", "설명", 1000, LocalDate.now().plusDays(7), "IT", "COMPLETED"
+        );
+
+        when(currentUserArgumentResolver.supportsParameter(any(MethodParameter.class))).thenReturn(true);
+        when(currentUserArgumentResolver.resolveArgument(any(), any(), any(), any())).thenReturn(userId);
+        when(projectService.updateProjectStatus(eq(userId), eq(projectId), any(ProjectStatusUpdateRequestDto.class)))
+                .thenReturn(responseDto);
+
+        mockMvc.perform(patch("/api/v1/projects/{projectId}/status", projectId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("COMPLETED"));
+    }
+
+    @Test
+    @DisplayName("프로젝트 등록 실패 - targetUserId 없음")
+    void registerProjectFail_missingTargetUserId() throws Exception {
+        ProjectRequestDto dto = new ProjectRequestDto(
+                null, // targetUserId 누락
+                "프로젝트명",
+                "설명",
+                1000,
+                LocalDate.now().plusDays(3),
+                "IT"
+        );
+
+        mockMvc.perform(post("/api/v1/projects")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("프로젝트 등록 실패 - 음수 예산")
+    void registerProjectFail_negativeBudget() throws Exception {
+        ProjectRequestDto dto = new ProjectRequestDto(
+                2L,
+                "프로젝트명",
+                "설명",
+                -100, // 예산 음수로 설정
+                LocalDate.now().plusDays(3),
+                "IT"
+        );
+
+        mockMvc.perform(post("/api/v1/projects")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/hotsix/server/project/service/ProjectServiceTest.java
+++ b/src/test/java/com/hotsix/server/project/service/ProjectServiceTest.java
@@ -1,0 +1,102 @@
+package com.hotsix.server.project.service;
+
+import com.hotsix.server.global.exception.ApplicationException;
+import com.hotsix.server.project.dto.ProjectRequestDto;
+import com.hotsix.server.project.entity.Project;
+import com.hotsix.server.project.entity.Status;
+import com.hotsix.server.project.repository.ProjectRepository;
+import com.hotsix.server.user.entity.Role;
+import com.hotsix.server.user.entity.User;
+import com.hotsix.server.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+public class ProjectServiceTest {
+
+    private ProjectService projectService;
+    private ProjectRepository projectRepository;
+    private UserRepository userRepository;
+
+    @BeforeEach
+    void setUp() {
+        projectRepository = mock(ProjectRepository.class);
+        userRepository = mock(UserRepository.class);
+        projectService = new ProjectService(projectRepository, userRepository);
+    }
+
+    @Test
+    @DisplayName("프로젝트 등록 성공 - 클라이언트 -> 프리랜서")
+    void projectRegSuccess() {
+        Long currentUserId = 1L;
+        Long targetUserId = 2L;
+
+        User client = User.builder().userId(currentUserId).role(Role.CLIENT).nickname("클라이언트").build();
+        User freelancer = User.builder().userId(targetUserId).role(Role.FREELANCER).nickname("프리랜서").build();
+
+        when(userRepository.findById(currentUserId)).thenReturn(java.util.Optional.of(client));
+        when(userRepository.findById(targetUserId)).thenReturn(java.util.Optional.of(freelancer));
+
+        ProjectRequestDto dto = new ProjectRequestDto(
+                targetUserId,
+                "테스트 프로젝트",
+                "설명",
+                1000,
+                LocalDate.now(),
+                "IT"
+        );
+
+        Project savedProject = Project.builder()
+                .projectId(1L)
+                .client(client)
+                .freelancer(freelancer)
+                .title(dto.title())
+                .description(dto.description())
+                .budget(dto.budget())
+                .deadline(dto.deadline())
+                .status(Status.OPEN)
+                .category(dto.category())
+                .build();
+
+        when(projectRepository.save(Mockito.any(Project.class))).thenReturn(savedProject);
+
+        var result = projectService.registerProject(currentUserId, dto);
+
+        assertThat(result.title()).isEqualTo(dto.title());
+        assertThat(result.clientNickname()).isEqualTo("클라이언트");
+        assertThat(result.freelancerNickname()).isEqualTo("프리랜서");
+    }
+
+    @Test
+    @DisplayName("프로젝트 등록 실패 - 역할 불일치")
+    void projectRegFail() {
+        Long currentUserId = 1L;
+        Long targetUserId = 2L;
+
+        User client1 = User.builder().userId(currentUserId).role(Role.CLIENT).build();
+        User client2 = User.builder().userId(targetUserId).role(Role.CLIENT).build();
+
+        when(userRepository.findById(currentUserId)).thenReturn(java.util.Optional.of(client1));
+        when(userRepository.findById(targetUserId)).thenReturn(java.util.Optional.of(client2));
+
+        ProjectRequestDto dto = new ProjectRequestDto(
+                targetUserId,
+                "제목",
+                "설명",
+                1000,
+                LocalDate.now(),
+                "IT"
+        );
+
+        assertThrows(ApplicationException.class, () -> {
+            projectService.registerProject(currentUserId, dto);
+        });
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #23 

## 📝 작업 내용
**1. ProjectServiceTest 구현**
- 클라이언트가 프리랜서 대상으로 정상적으로 프로젝트 등록 확인 
- 클라이언트 → 클라이언트로 등록 시 예외 발생 확인  

**2. ProjectControllerTest 구현**
- 정상적인 프로젝트 등록, 상태 변경에 관한 테스트 확인 성공
- targetUserId 누락, 예산이 음수일 경우 예외 발생 확인

## 🖼️ 스크린샷 (선택)

> UI 변경 등 시각적으로 확인할 수 있는 내용이 있다면 첨부해주세요

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 테스트
  * ProjectController 테스트 추가: MockMvc 단독 구성, ObjectMapper(JavaTimeModule) 설정, CurrentUserArgumentResolver 스텁. 프로젝트 등록 성공, 상태 변경 성공, targetUserId 누락 및 음수 예산 유효성 실패(400) 검증.
  * ProjectService 테스트 추가: 저장·조회 목킹으로 서비스 로직 검증. 등록 성공 시 제목과 의뢰자/프리랜서 닉네임 확인, 잘못된 역할 매칭 시 예외 발생 확인.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->