### PR TITLE
[feat] 리뷰 수정,삭제 API 구현 및 관련 테스트코드 로직 추가 

### DIFF
--- a/src/main/java/com/hotsix/server/review/controller/ReviewController.java
+++ b/src/main/java/com/hotsix/server/review/controller/ReviewController.java
@@ -72,4 +72,38 @@ public class ReviewController {
     ) {
         return CommonResponse.success(reviewService.getReviewsByProject(projectId));
     }
+
+    @PatchMapping("/{reviewId}")
+    @Operation(summary = "리뷰 수정", description = "작성한 리뷰를 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "리뷰 수정 성공"),
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 평점"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자 요청"),
+            @ApiResponse(responseCode = "403", description = "수정 권한 없음"),
+            @ApiResponse(responseCode = "404", description = "리뷰를 찾을 수 없음")
+    })
+    public CommonResponse<String> updateReview(
+            @Parameter(hidden = true) @CurrentUser Long userId,
+            @PathVariable Long reviewId,
+            @RequestBody @Valid ReviewRequestDto dto
+    ) {
+        reviewService.updateReview(userId, reviewId, dto);
+        return CommonResponse.success("리뷰가 수정되었습니다.");
+    }
+
+    @DeleteMapping("/{reviewId}")
+    @Operation(summary = "리뷰 삭제", description = "작성한 리뷰를 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "리뷰 삭제 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자 요청"),
+            @ApiResponse(responseCode = "403", description = "삭제 권한 없음"),
+            @ApiResponse(responseCode = "404", description = "리뷰를 찾을 수 없음")
+    })
+    public CommonResponse<String> deleteReview(
+            @Parameter(hidden = true) @CurrentUser Long userId,
+            @PathVariable Long reviewId
+    ) {
+        reviewService.deleteReview(userId, reviewId);
+        return CommonResponse.success("리뷰가 삭제되었습니다.");
+    }
 }

--- a/src/main/java/com/hotsix/server/review/entity/Review.java
+++ b/src/main/java/com/hotsix/server/review/entity/Review.java
@@ -52,4 +52,7 @@ public class Review extends BaseEntity {
                 .comment(comment)
                 .build();
     }
+
+    public void setRating(BigDecimal rating) { this.rating = rating; }
+    public void setComment(String comment) { this.comment = comment; }
 }

--- a/src/main/java/com/hotsix/server/review/entity/Review.java
+++ b/src/main/java/com/hotsix/server/review/entity/Review.java
@@ -55,4 +55,8 @@ public class Review extends BaseEntity {
 
     public void setRating(BigDecimal rating) { this.rating = rating; }
     public void setComment(String comment) { this.comment = comment; }
+    public void update(BigDecimal rating, String comment) {
+        this.rating = rating;
+        this.comment = comment;
+    }
 }

--- a/src/main/java/com/hotsix/server/review/service/ReviewService.java
+++ b/src/main/java/com/hotsix/server/review/service/ReviewService.java
@@ -133,12 +133,17 @@ public class ReviewService {
 
         // 이미지 갱신 (기존 이미지 삭제 후 새로 저장)
         reviewImageRepository.deleteAll(review.getReviewImageList());
+        review.getReviewImageList().clear();
+
         if (dto.images() != null && !dto.images().isEmpty()) {
             List<ReviewImage> images = dto.images().stream()
                     .map(img -> ReviewImage.of(review, img))
                     .toList();
-            reviewImageRepository.saveAll(images);
         }
+
+        review.update(dto.rating(), dto.comment());
+
+        reviewRepository.save(review);
     }
 
     @Transactional


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #18 

## 📝 작업 내용
1. 리뷰 수정 API 구현
2. 리뷰 삭제 API 구현
3. 리뷰 수정 및 삭제에 대한 서비스 관련 테스트코드 로직 추가 (테스트 통과 확인)
4. 리뷰 수정 및 삭제에 대한 컨트롤러 관련 테스트코드 로직 추가 (테스트 통과 확인)

## 🖼️ 스크린샷 (선택)
### 리뷰 수정 성공
<img width="1472" height="942" alt="리뷰수정성공" src="https://github.com/user-attachments/assets/dd397485-6f2b-491a-80a4-9eb048245c85" />

### 리뷰 삭제 성공
<img width="1465" height="903" alt="리뷰삭제성공" src="https://github.com/user-attachments/assets/1fe83a93-8da0-436e-8647-6b6de7c38156" />


## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요