### PR TITLE
[feat] 관리자 로그인, 대시보드 API 구현 

### DIFF
--- a/src/main/java/com/hotsix/server/admin/config/AdminAuthInterceptor.java
+++ b/src/main/java/com/hotsix/server/admin/config/AdminAuthInterceptor.java
@@ -57,6 +57,6 @@ public class AdminAuthInterceptor implements HandlerInterceptor {
             return false;
         }
 
-        return true; 
+        return true;
     }
 }

--- a/src/main/java/com/hotsix/server/admin/config/AdminAuthInterceptor.java
+++ b/src/main/java/com/hotsix/server/admin/config/AdminAuthInterceptor.java
@@ -1,0 +1,62 @@
+package com.hotsix.server.admin.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+@Component
+@RequiredArgsConstructor
+public class AdminAuthInterceptor implements HandlerInterceptor {
+
+    private final AdminProperties adminProperties;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        // 로그인 API는 인증 제외
+        if (request.getRequestURI().equals("/api/v1/admin/login")) {
+            return true;
+        }
+
+        String authHeader = request.getHeader("Authorization");
+
+        if (authHeader == null || !authHeader.startsWith("Basic ")) {
+            response.setStatus(401);
+            response.setContentType("application/json;charset=UTF-8");
+            response.getWriter().write("{\"message\": \"인증 정보가 없습니다. 관리자 계정으로 로그인해주세요.\"}");
+            return false;
+        }
+
+        try {
+            String base64Credentials = authHeader.substring("Basic ".length());
+            String credentials = new String(Base64.getDecoder().decode(base64Credentials), StandardCharsets.UTF_8);
+            String[] values = credentials.split(":", 2);
+
+            if (values.length != 2) {
+                throw new IllegalArgumentException("잘못된 인증 헤더 형식입니다.");
+            }
+
+            String username = values[0];
+            String password = values[1];
+
+            if (!username.equals(adminProperties.getUsername()) || !password.equals(adminProperties.getPassword())) {
+                response.setStatus(401);
+                response.setContentType("application/json;charset=UTF-8");
+                response.getWriter().write("{\"message\": \"아이디 또는 비밀번호가 올바르지 않습니다.\"}");
+                return false;
+            }
+
+        } catch (IllegalArgumentException e) {
+            response.setStatus(401);
+            response.setContentType("application/json;charset=UTF-8");
+            response.getWriter().write("{\"message\": \"잘못된 인증 정보입니다. 관리자 계정 확인이 필요합니다.\"}");
+            return false;
+        }
+
+        return true; 
+    }
+}

--- a/src/main/java/com/hotsix/server/admin/config/AdminProperties.java
+++ b/src/main/java/com/hotsix/server/admin/config/AdminProperties.java
@@ -1,0 +1,15 @@
+package com.hotsix.server.admin.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "admin")
+public class AdminProperties {
+    private String username;
+    private String password;
+}

--- a/src/main/java/com/hotsix/server/admin/controller/AdminController.java
+++ b/src/main/java/com/hotsix/server/admin/controller/AdminController.java
@@ -1,18 +1,28 @@
 package com.hotsix.server.admin.controller;
 
-
-import com.hotsix.server.admin.service.CategoryService;
-import com.hotsix.server.admin.service.ReportService;
+import com.hotsix.server.admin.config.AdminProperties;
+import com.hotsix.server.admin.dto.AdminLoginRequestDto;
+import com.hotsix.server.global.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/admin")
 @RequiredArgsConstructor
 public class AdminController {
+    private final AdminProperties adminProperties;
 
-    private final CategoryService categoryService;
-    private final ReportService reportService;
+    @PostMapping("/login")
+    @Operation(summary = "관리자 로그인", description = "application.yml에 등록된 관리자 계정으로 로그인")
+    public ResponseEntity<CommonResponse<String>> login(@RequestBody @Valid AdminLoginRequestDto request) {
+        if (!request.username().equals(adminProperties.getUsername())
+                || !request.password().equals(adminProperties.getPassword())) {
+            return ResponseEntity.status(401)
+                    .body(CommonResponse.error(401, "아이디 또는 비밀번호가 일치하지 않습니다."));
+        }
+        return ResponseEntity.ok(CommonResponse.success("로그인 성공"));
+    }
 }

--- a/src/main/java/com/hotsix/server/admin/controller/AdminController.java
+++ b/src/main/java/com/hotsix/server/admin/controller/AdminController.java
@@ -1,7 +1,9 @@
 package com.hotsix.server.admin.controller;
 
 import com.hotsix.server.admin.config.AdminProperties;
+import com.hotsix.server.admin.dto.AdminDashboardResponseDto;
 import com.hotsix.server.admin.dto.AdminLoginRequestDto;
+import com.hotsix.server.admin.service.AdminDashboardService;
 import com.hotsix.server.global.response.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
@@ -14,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class AdminController {
     private final AdminProperties adminProperties;
+    private final AdminDashboardService adminDashboardService;
 
     @PostMapping("/login")
     @Operation(summary = "관리자 로그인", description = "application.yml에 등록된 관리자 계정으로 로그인")
@@ -24,5 +27,11 @@ public class AdminController {
                     .body(CommonResponse.error(401, "아이디 또는 비밀번호가 일치하지 않습니다."));
         }
         return ResponseEntity.ok(CommonResponse.success("로그인 성공"));
+    }
+
+    @GetMapping("/dashboard")
+    @Operation(summary = "관리자 대시보드 통계 조회")
+    public CommonResponse<AdminDashboardResponseDto> getDashboard() {
+        return CommonResponse.success(adminDashboardService.getDashboard());
     }
 }

--- a/src/main/java/com/hotsix/server/admin/dto/AdminDashboardResponseDto.java
+++ b/src/main/java/com/hotsix/server/admin/dto/AdminDashboardResponseDto.java
@@ -1,0 +1,13 @@
+package com.hotsix.server.admin.dto;
+
+import java.util.List;
+
+public record AdminDashboardResponseDto(
+        long totalUserCount,
+        long todayUserCount,
+        long todayFreelancerSignups,
+        long todayClientSignups,
+        long todayProjectCount,
+        long todayReviewCount,
+        List<AdminRecentProjectDto> recentProjects
+) {}

--- a/src/main/java/com/hotsix/server/admin/dto/AdminLoginRequestDto.java
+++ b/src/main/java/com/hotsix/server/admin/dto/AdminLoginRequestDto.java
@@ -1,0 +1,8 @@
+package com.hotsix.server.admin.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AdminLoginRequestDto(
+        @NotBlank String username,
+        @NotBlank String password
+) {}

--- a/src/main/java/com/hotsix/server/admin/dto/AdminRecentProjectDto.java
+++ b/src/main/java/com/hotsix/server/admin/dto/AdminRecentProjectDto.java
@@ -1,0 +1,20 @@
+package com.hotsix.server.admin.dto;
+
+import com.hotsix.server.project.entity.Project;
+import java.time.LocalDateTime;
+
+public record AdminRecentProjectDto(
+        Long projectId,
+        String title,
+        String createdByNickname,
+        LocalDateTime createdAt
+) {
+    public static AdminRecentProjectDto from(Project project) {
+        return new AdminRecentProjectDto(
+                project.getProjectId(),
+                project.getTitle(),
+                project.getCreatedBy().getNickname(),
+                project.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/hotsix/server/admin/dto/AdminRecentProjectDto.java
+++ b/src/main/java/com/hotsix/server/admin/dto/AdminRecentProjectDto.java
@@ -10,10 +10,14 @@ public record AdminRecentProjectDto(
         LocalDateTime createdAt
 ) {
     public static AdminRecentProjectDto from(Project project) {
+        String nickname = (project.getCreatedBy() != null)
+                ? project.getCreatedBy().getNickname()
+                : project.getClient().getNickname();
+
         return new AdminRecentProjectDto(
                 project.getProjectId(),
                 project.getTitle(),
-                project.getCreatedBy().getNickname(),
+                nickname,
                 project.getCreatedAt()
         );
     }

--- a/src/main/java/com/hotsix/server/admin/service/AdminDashboardService.java
+++ b/src/main/java/com/hotsix/server/admin/service/AdminDashboardService.java
@@ -1,0 +1,50 @@
+package com.hotsix.server.admin.service;
+
+import com.hotsix.server.admin.dto.AdminDashboardResponseDto;
+import com.hotsix.server.admin.dto.AdminRecentProjectDto;
+import com.hotsix.server.project.repository.ProjectRepository;
+import com.hotsix.server.review.repository.ReviewRepository;
+import com.hotsix.server.user.entity.Role;
+import com.hotsix.server.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AdminDashboardService {
+
+    private final UserRepository userRepository;
+    private final ProjectRepository projectRepository;
+    private final ReviewRepository reviewRepository;
+
+    @Transactional(readOnly = true)
+    public AdminDashboardResponseDto getDashboard() {
+        LocalDate today = LocalDate.now();
+
+        long totalUserCount = userRepository.countAllUsers();
+        long todayUserCount = userRepository.countUsersByCreatedDate(today);
+        long todayFreelancerSignups = userRepository.countByRoleAndCreatedDate(Role.FREELANCER, today);
+        long todayClientSignups = userRepository.countByRoleAndCreatedDate(Role.CLIENT, today);
+        long todayProjectCount = projectRepository.countByCreatedDate(today);
+        long todayReviewCount = reviewRepository.countByCreatedDate(today);
+
+        List<AdminRecentProjectDto> recentProjects = projectRepository.findTop10ByOrderByCreatedAtDesc()
+                .stream()
+                .map(AdminRecentProjectDto::from)
+                .toList();
+
+        return new AdminDashboardResponseDto(
+                totalUserCount,
+                todayUserCount,
+                todayFreelancerSignups,
+                todayClientSignups,
+                todayProjectCount,
+                todayReviewCount,
+                recentProjects
+        );
+    }
+}

--- a/src/main/java/com/hotsix/server/admin/service/AdminDashboardService.java
+++ b/src/main/java/com/hotsix/server/admin/service/AdminDashboardService.java
@@ -7,10 +7,12 @@ import com.hotsix.server.review.repository.ReviewRepository;
 import com.hotsix.server.user.entity.Role;
 import com.hotsix.server.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 
 @Service
@@ -23,7 +25,7 @@ public class AdminDashboardService {
 
     @Transactional(readOnly = true)
     public AdminDashboardResponseDto getDashboard() {
-        LocalDate today = LocalDate.now();
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
 
         long totalUserCount = userRepository.countAllUsers();
         long todayUserCount = userRepository.countUsersByCreatedDate(today);
@@ -32,7 +34,8 @@ public class AdminDashboardService {
         long todayProjectCount = projectRepository.countByCreatedDate(today);
         long todayReviewCount = reviewRepository.countByCreatedDate(today);
 
-        List<AdminRecentProjectDto> recentProjects = projectRepository.findTop10ByOrderByCreatedAtDesc()
+        List<AdminRecentProjectDto> recentProjects = projectRepository
+                .findTop10ByOrderByCreatedAtDescWithUser(PageRequest.of(0, 10))
                 .stream()
                 .map(AdminRecentProjectDto::from)
                 .toList();

--- a/src/main/java/com/hotsix/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/hotsix/server/global/config/SecurityConfig.java
@@ -47,8 +47,10 @@ public class SecurityConfig {
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
                                 "/api/v1/users/login",
-                                "/api/v1/users/signup"
+                                "/api/v1/users/signup",
+                                "/api/v1/admin/login"
                         ).permitAll()
+                        .requestMatchers("/api/v1/admin/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(exception -> exception

--- a/src/main/java/com/hotsix/server/global/config/WebMvcConfig.java
+++ b/src/main/java/com/hotsix/server/global/config/WebMvcConfig.java
@@ -1,9 +1,11 @@
 package com.hotsix.server.global.config;
 
+import com.hotsix.server.admin.config.AdminAuthInterceptor;
 import com.hotsix.server.auth.resolver.CurrentUserArgumentResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.List;
@@ -13,9 +15,17 @@ import java.util.List;
 public class WebMvcConfig implements WebMvcConfigurer {
 
     private final CurrentUserArgumentResolver currentUserArgumentResolver;
+    private final AdminAuthInterceptor adminAuthInterceptor;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(currentUserArgumentResolver);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(adminAuthInterceptor)
+                .addPathPatterns("/api/v1/admin/**")
+                .excludePathPatterns("/api/v1/admin/login"); // 로그인은 예외
     }
 }

--- a/src/main/java/com/hotsix/server/global/config/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/hotsix/server/global/config/security/jwt/JwtAuthenticationFilter.java
@@ -23,6 +23,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     HttpServletResponse res,
                                     FilterChain chain) throws ServletException, IOException {
 
+        String uri = req.getRequestURI();
+        if (uri.startsWith("/api/v1/admin")) {
+            chain.doFilter(req, res);
+            return;
+        }
+
         String token = null;
 
         String header = req.getHeader("Authorization");

--- a/src/main/java/com/hotsix/server/project/entity/Project.java
+++ b/src/main/java/com/hotsix/server/project/entity/Project.java
@@ -39,6 +39,10 @@ public class Project extends BaseEntity {
 
     private String category;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "created_by_user_id", nullable = false)
+    private User createdBy;
+
     public void updateStatus(Status newStatus) {
         if (this.status == Status.COMPLETED && newStatus != Status.COMPLETED) {
             throw new IllegalStateException("완료된 프로젝트의 상태는 변경할 수 없습니다.");

--- a/src/main/java/com/hotsix/server/project/entity/Project.java
+++ b/src/main/java/com/hotsix/server/project/entity/Project.java
@@ -40,7 +40,7 @@ public class Project extends BaseEntity {
     private String category;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "created_by_user_id", nullable = false)
+    @JoinColumn(name = "created_by_user_id", nullable = true)
     private User createdBy;
 
     public void updateStatus(Status newStatus) {

--- a/src/main/java/com/hotsix/server/project/repository/ProjectRepository.java
+++ b/src/main/java/com/hotsix/server/project/repository/ProjectRepository.java
@@ -4,6 +4,7 @@ import com.hotsix.server.project.entity.Project;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -12,5 +13,6 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
     @Query("SELECT COUNT(p) FROM Project p WHERE DATE(p.createdAt) = :date")
     long countByCreatedDate(@Param("date") LocalDate date);
 
-    List<Project> findTop10ByOrderByCreatedAtDesc();
+    @Query("SELECT p FROM Project p LEFT JOIN FETCH p.createdBy ORDER BY p.createdAt DESC")
+    List<Project> findTop10ByOrderByCreatedAtDescWithUser(Pageable pageable);
 }

--- a/src/main/java/com/hotsix/server/project/repository/ProjectRepository.java
+++ b/src/main/java/com/hotsix/server/project/repository/ProjectRepository.java
@@ -2,6 +2,15 @@ package com.hotsix.server.project.repository;
 
 import com.hotsix.server.project.entity.Project;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public interface ProjectRepository extends JpaRepository<Project, Long> {
+    @Query("SELECT COUNT(p) FROM Project p WHERE DATE(p.createdAt) = :date")
+    long countByCreatedDate(@Param("date") LocalDate date);
+
+    List<Project> findTop10ByOrderByCreatedAtDesc();
 }

--- a/src/main/java/com/hotsix/server/project/service/ProjectService.java
+++ b/src/main/java/com/hotsix/server/project/service/ProjectService.java
@@ -50,6 +50,7 @@ public class ProjectService {
                     .deadline(dto.deadline())
                     .status(Status.OPEN)
                     .category(dto.category())
+                    .createdBy(currentUser)
                     .build();
         } else if (currentUser.getRole() == Role.FREELANCER) {
             if (targetUser.getRole() != Role.CLIENT) {
@@ -65,6 +66,7 @@ public class ProjectService {
                     .deadline(dto.deadline())
                     .status(Status.OPEN)
                     .category(dto.category())
+                    .createdBy(currentUser)
                     .build();
         } else {
             // Role이 둘 다 아니면 예외 처리

--- a/src/main/java/com/hotsix/server/review/repository/ReviewRepository.java
+++ b/src/main/java/com/hotsix/server/review/repository/ReviewRepository.java
@@ -2,7 +2,10 @@ package com.hotsix.server.review.repository;
 
 import com.hotsix.server.review.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
@@ -12,4 +15,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     boolean existsByProject_ProjectIdAndFromUser_UserId(Long projectId, Long fromUserId);
 
     List<Review> findAllByProject_ProjectId(Long projectId);
+
+    @Query("SELECT COUNT(r) FROM Review r WHERE DATE(r.createdAt) = :date")
+    long countByCreatedDate(@Param("date") LocalDate date);
 }

--- a/src/main/java/com/hotsix/server/user/repository/UserRepository.java
+++ b/src/main/java/com/hotsix/server/user/repository/UserRepository.java
@@ -1,10 +1,23 @@
 package com.hotsix.server.user.repository;
 
+import com.hotsix.server.user.entity.Role;
 import com.hotsix.server.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+
+    @Query("SELECT COUNT(u) FROM User u")
+    long countAllUsers();
+
+    @Query("SELECT COUNT(u) FROM User u WHERE DATE(u.createdAt) = :date")
+    long countUsersByCreatedDate(@Param("date") LocalDate date);
+
+    @Query("SELECT COUNT(u) FROM User u WHERE u.role = :role AND DATE(u.createdAt) = :date")
+    long countByRoleAndCreatedDate(@Param("role") Role role, @Param("date") LocalDate date);
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #28 

## 📝 작업 내용
**1. 관리자 로그인 기능**
- Basic 인증 기반 인터셉터 구현

**2. 관리자 계정 정보는 `application.yml`에서 주입받도록 구성**
**3. 어드민 전용 API 인터셉터 설정**
**4. 대시보드 API 구현:**
  - 전체 유저 수, 오늘 가입자 수
  - 오늘 등록된 프로젝트 수 / 리뷰 수
  - 최근 가입 유저 목록 (프리랜서 / 클라이언트 구분)
  - 최근 등록된 프로젝트 목록 (작성자 포함)


## 🖼️ 스크린샷 (선택)
### 어드민 대시보드 통계 테스트 (curl)
<img width="1654" height="44" alt="어드민성공" src="https://github.com/user-attachments/assets/79edb783-8fb5-4e63-ada8-be251023652e" />


## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 관리자 로그인 엔드포인트 추가로 관리자 계정 인증 가능
  - 관리자 대시보드 추가: 전체/일일 사용자, 역할별 가입, 신규 프로젝트/리뷰 수, 최근 프로젝트 목록 제공
- 보안
  - 관리자 API에 기본 인증 적용(로그인 엔드포인트 제외)으로 접근 제어 강화
- 개선
  - 프로젝트에 작성자 정보 연계로 대시보드 및 목록의 표시가 더 풍부해짐
<!-- end of auto-generated comment: release notes by coderabbit.ai -->