### PR TITLE
[fix] 제안서 등록 시 파일 등록기능 제거 및 유저 등록시 role이 입력에 따라 바뀌게 변경

### DIFF
--- a/src/main/java/com/hotsix/server/message/dto/MessageResponseDto.java
+++ b/src/main/java/com/hotsix/server/message/dto/MessageResponseDto.java
@@ -15,7 +15,7 @@ public record MessageResponseDto (
         this(
                 message.getMessageId(),
                 message.getCreatedAt(),
-                message.getSender().getName(),
+                message.getSender().getNickname(),
                 message.getContent()
         );
     }

--- a/src/main/java/com/hotsix/server/message/dto/MessageResponseDto.java
+++ b/src/main/java/com/hotsix/server/message/dto/MessageResponseDto.java
@@ -15,7 +15,7 @@ public record MessageResponseDto (
         this(
                 message.getMessageId(),
                 message.getCreatedAt(),
-                message.getSender().getNickname(),
+                message.getSender().getName(),
                 message.getContent()
         );
     }

--- a/src/main/java/com/hotsix/server/proposal/controller/ProposalController.java
+++ b/src/main/java/com/hotsix/server/proposal/controller/ProposalController.java
@@ -1,6 +1,5 @@
 package com.hotsix.server.proposal.controller;
 
-import com.hotsix.server.global.Rq.Rq;
 import com.hotsix.server.global.response.CommonResponse;
 import com.hotsix.server.proposal.dto.ProposalRequestBody;
 import com.hotsix.server.proposal.dto.ProposalRequestDto;
@@ -13,7 +12,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -24,7 +22,6 @@ import java.util.List;
 @Tag(name = "ProposalController", description = "API 제안서 컨트롤러")
 public class ProposalController {
     private final ProposalService proposalService;
-    private final Rq rq;
 
     @GetMapping
     @Operation(summary = "제안서 다건 조회")
@@ -48,17 +45,18 @@ public class ProposalController {
         );
     }
 
-    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping/*(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)*/
     @Operation(summary = "제안서 작성")
     public CommonResponse<ProposalResponseDto> createProposal(
             @Valid @RequestBody ProposalRequestDto proposalRequestDto
+            //@RequestPart(value = "files", required = false) List<ProposalFile> files
     ){
 
         Proposal proposal = proposalService.create(
                 proposalRequestDto.projectId(),
                 proposalRequestDto.description(),
                 proposalRequestDto.proposedAmount(),
-                proposalRequestDto.portfolioFiles(),
+                //files,
                 ProposalStatus.SUBMITTED
         );
 
@@ -83,7 +81,7 @@ public class ProposalController {
             @PathVariable long id,
             @Valid @RequestBody ProposalRequestBody requestBody
     ){
-        proposalService.update(id, requestBody.description(), requestBody.proposedAmount(), requestBody.portfolioFiles());
+        proposalService.update(id, requestBody.description(), requestBody.proposedAmount()/*, requestBody.portfolioFiles()*/);
 
         return CommonResponse.success("%d번 제안서가 수정되었습니다.".formatted(id));
     }

--- a/src/main/java/com/hotsix/server/proposal/dto/ProposalRequestBody.java
+++ b/src/main/java/com/hotsix/server/proposal/dto/ProposalRequestBody.java
@@ -1,18 +1,15 @@
 package com.hotsix.server.proposal.dto;
 
-import com.hotsix.server.proposal.entity.proposalPorfolio.ProposalFile;
 import jakarta.persistence.Lob;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-
-import java.util.List;
 
 public record ProposalRequestBody (
         @NotBlank
         @Lob
         String description,
         @NotNull
-        Integer proposedAmount,
-        List<ProposalFile> portfolioFiles
+        Integer proposedAmount
+        //List<ProposalFile> portfolioFiles
 ){
 }

--- a/src/main/java/com/hotsix/server/proposal/dto/ProposalRequestDto.java
+++ b/src/main/java/com/hotsix/server/proposal/dto/ProposalRequestDto.java
@@ -1,11 +1,8 @@
 package com.hotsix.server.proposal.dto;
 
-import com.hotsix.server.proposal.entity.proposalPorfolio.ProposalFile;
 import jakarta.persistence.Lob;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-
-import java.util.List;
 
 public record ProposalRequestDto (
         @NotNull
@@ -14,7 +11,6 @@ public record ProposalRequestDto (
         @Lob
         String description,
         @NotNull
-        Integer proposedAmount,
-        List<ProposalFile> portfolioFiles
+        Integer proposedAmount
 ){
 }

--- a/src/main/java/com/hotsix/server/proposal/dto/ProposalResponseDto.java
+++ b/src/main/java/com/hotsix/server/proposal/dto/ProposalResponseDto.java
@@ -1,23 +1,20 @@
 package com.hotsix.server.proposal.dto;
 
 import com.hotsix.server.proposal.entity.Proposal;
-import com.hotsix.server.proposal.entity.proposalPorfolio.ProposalFile;
 import com.hotsix.server.proposal.entity.ProposalStatus;
-import com.hotsix.server.user.entity.User;
 import org.springframework.lang.NonNull;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 public record ProposalResponseDto (
         Long proposalId,
         @NonNull LocalDateTime createDate,
         @NonNull LocalDateTime updateDate,
         @NonNull Long projectId,
-        @NonNull User sender,
+        @NonNull Long senderId,
         @NonNull String description,
         @NonNull Integer proposedAmount,
-        List<ProposalFile> portfolioFiles,
+        //List<ProposalFile> portfolioFiles,
         @NonNull ProposalStatus proposalStatus
 ){
     public ProposalResponseDto(Proposal proposal){
@@ -26,10 +23,10 @@ public record ProposalResponseDto (
                 proposal.getCreatedAt(),
                 proposal.getUpdatedAt(),
                 proposal.getProject().getProjectId(),
-                proposal.getSender(),
+                proposal.getSender().getUserId(),
                 proposal.getDescription(),
                 proposal.getProposedAmount(),
-                proposal.getPortfolioFiles(),
+                //proposal.getPortfolioFiles(),
                 proposal.getProposalStatus()
         );
     }

--- a/src/main/java/com/hotsix/server/proposal/entity/Proposal.java
+++ b/src/main/java/com/hotsix/server/proposal/entity/Proposal.java
@@ -2,15 +2,11 @@ package com.hotsix.server.proposal.entity;
 
 import com.hotsix.server.global.entity.BaseEntity;
 import com.hotsix.server.global.exception.ApplicationException;
-import com.hotsix.server.proposal.entity.proposalPorfolio.ProposalFile;
-import com.hotsix.server.proposal.exception.ProposalErrorCase;
 import com.hotsix.server.project.entity.Project;
+import com.hotsix.server.proposal.exception.ProposalErrorCase;
+import com.hotsix.server.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
-import com.hotsix.server.user.entity.User;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -37,9 +33,9 @@ public class Proposal extends BaseEntity {
 
     private Integer proposedAmount;
 
-    @Builder.Default
-    @OneToMany(mappedBy = "proposal", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<ProposalFile> portfolioFiles = new ArrayList<>();
+//    @Builder.Default
+//    @OneToMany(mappedBy = "proposal", cascade = CascadeType.ALL, orphanRemoval = true)
+//    private List<ProposalFile> portfolioFiles = new ArrayList<>();
 
     @Enumerated(EnumType.STRING)
     private ProposalStatus proposalStatus; // DRAFT, SUBMITTED, ACCEPTED, REJECTED
@@ -56,10 +52,10 @@ public class Proposal extends BaseEntity {
         }
     }
 
-    public void modify(String description, Integer proposedAmount, List<ProposalFile> proposalFiles) {
+    public void modify(String description, Integer proposedAmount/*, List<ProposalFile> proposalFiles*/) {
         this.description = description;
         this.proposedAmount = proposedAmount;
-        this.portfolioFiles = proposalFiles;
+        //this.portfolioFiles = proposalFiles;
     }
 
     public void modify(ProposalStatus proposalStatus) {

--- a/src/main/java/com/hotsix/server/proposal/entity/proposalPorfolio/ProposalFile.java
+++ b/src/main/java/com/hotsix/server/proposal/entity/proposalPorfolio/ProposalFile.java
@@ -1,27 +1,27 @@
-package com.hotsix.server.proposal.entity.proposalPorfolio;
-
-import com.hotsix.server.proposal.entity.Proposal;
-import jakarta.persistence.*;
-import lombok.*;
-
-@Entity
-@Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-@Builder
-@Table(name = "proposal_files")
-public class ProposalFile {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long proposalFileId;
-
-    private String fileName;     // 원본 파일명
-    private String filePath;     // 저장된 경로 or URL
-    private String fileType;     // MIME 타입 (pdf, png, etc)
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "proposal_id")
-    private Proposal proposal;
-}
+//package com.hotsix.server.proposal.entity.proposalPorfolio;
+//
+//import com.hotsix.server.proposal.entity.Proposal;
+//import jakarta.persistence.*;
+//import lombok.*;
+//
+//@Entity
+//@Getter
+//@NoArgsConstructor(access = AccessLevel.PROTECTED)
+//@AllArgsConstructor
+//@Builder
+//@Table(name = "proposal_files")
+//public class ProposalFile {
+//
+//    @Id
+//    @GeneratedValue(strategy = GenerationType.IDENTITY)
+//    private Long proposalFileId;
+//
+//    private String fileName;     // 원본 파일명
+//    private String filePath;     // 저장된 경로 or URL
+//    private String fileType;     // MIME 타입 (pdf, png, etc)
+//
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "proposal_id")
+//    private Proposal proposal;
+//}
 

--- a/src/main/java/com/hotsix/server/proposal/service/ProposalService.java
+++ b/src/main/java/com/hotsix/server/proposal/service/ProposalService.java
@@ -6,7 +6,6 @@ import com.hotsix.server.project.entity.Project;
 import com.hotsix.server.project.service.ProjectService;
 import com.hotsix.server.proposal.dto.ProposalResponseDto;
 import com.hotsix.server.proposal.entity.Proposal;
-import com.hotsix.server.proposal.entity.proposalPorfolio.ProposalFile;
 import com.hotsix.server.proposal.entity.ProposalStatus;
 import com.hotsix.server.proposal.exception.ProposalErrorCase;
 import com.hotsix.server.proposal.repository.ProposalRepository;
@@ -36,7 +35,7 @@ public class ProposalService {
     }
 
     @Transactional
-    public Proposal create(Long projectId, String description, Integer proposedAmount, List<ProposalFile> proposalFiles, ProposalStatus proposalStatus) {
+    public Proposal create(Long projectId, String description, Integer proposedAmount, /*List<ProposalFile> proposalFiles,*/ ProposalStatus proposalStatus) {
 
         Project project = projectService.findById(projectId);
 
@@ -47,7 +46,7 @@ public class ProposalService {
                 .sender(actor)
                 .description(description)
                 .proposedAmount(proposedAmount)
-                .portfolioFiles(proposalFiles)
+                //.portfolioFiles(proposalFiles)
                 .proposalStatus(proposalStatus)
                 .build();
 
@@ -69,11 +68,11 @@ public class ProposalService {
     }
 
     @Transactional
-    public void update(long id, String description, Integer proposedAmount, List<ProposalFile> proposalFiles) {
+    public void update(long id, String description, Integer proposedAmount/*, List<ProposalFile> proposalFiles*/) {
         Proposal proposal = findById(id);
         User actor = rq.getUser();
         proposal.checkCanModify(actor);
-        proposal.modify(description, proposedAmount, proposalFiles);
+        proposal.modify(description, proposedAmount/*, proposalFiles*/);
     }
 
     @Transactional

--- a/src/main/java/com/hotsix/server/user/controller/UserController.java
+++ b/src/main/java/com/hotsix/server/user/controller/UserController.java
@@ -37,7 +37,7 @@ public class UserController {
             }
     )
     public RsData<UserDto> join(@Valid @RequestBody UserRegisterRequestDto reqBody) {
-        User user = userService.signUp(reqBody.email(), reqBody.password(), reqBody.birthDate(), reqBody.name(), reqBody.nickname(), reqBody.phoneNumber());
+        User user = userService.signUp(reqBody.email(), reqBody.password(), reqBody.birthDate(), reqBody.name(), reqBody.nickname(), reqBody.phoneNumber(), reqBody.role());
 
         return new RsData<>(
                 "201-1",

--- a/src/main/java/com/hotsix/server/user/service/UserService.java
+++ b/src/main/java/com/hotsix/server/user/service/UserService.java
@@ -28,7 +28,9 @@ public class UserService {
                        LocalDate birthdate,
                        String name,
                        String nickname,
-                       String phoneNumber) {
+                       String phoneNumber,
+                       Role userRole
+                       ) {
 
         userRepository.findByEmail(email)
                 .ifPresent(_user -> {
@@ -40,7 +42,6 @@ public class UserService {
                     throw new ApplicationException(UserErrorCase.NICKNAME_ALREADY_EXISTS);
                 });
 
-        Role userRole = Role.CLIENT;
         Provider userProvider = Provider.NORMAL;
         password = passwordEncoder.encode(password);
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #12, #19 

## 📝 작업 내용

> 제안서 등록시 파일 등록되는 기능 잠시 제거했습니다. 현재 swagger에서 제안서 기능 정상작동 합니다.
> 유저 등록시 기존에 role이 client로 고정되어서 이를 입력에 따라 바뀌게 변경하였습니다.

## 🖼️ 스크린샷 (선택)

> UI 변경 등 시각적으로 확인할 수 있는 내용이 있다면 첨부해주세요

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 회원가입 시 역할(Role) 선택을 지원합니다.
- 리팩터링
  - 제안 생성/수정에서 포트폴리오 파일 업로드가 비활성화되었습니다(멀티파트 요청 미지원). 요청 본문의 portfolioFiles 필드가 제거되었습니다.
  - 제안 응답이 단순화되었습니다: 발신자 정보는 객체 대신 senderId만 반환하며, 포트폴리오 파일 목록이 제거되었습니다.
  - 메시지에서 발신자 표기가 닉네임에서 실명(이름)으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->