### PR TITLE
[fix] 메세지 서비스에 Transaction 어노테이션 추가

### DIFF
--- a/src/main/java/com/hotsix/server/message/controller/MessageController.java
+++ b/src/main/java/com/hotsix/server/message/controller/MessageController.java
@@ -25,10 +25,10 @@ public class MessageController {
     public CommonResponse<List<MessageResponseDto>> getMessagesByProjectId(
             @PathVariable long projectId
     ) {
-        List<Message> messages = messageService.findByProjectIdOrderByCreatedAtAsc(projectId);
+        List<MessageResponseDto> messageResponseDtos = messageService.findByProjectIdOrderByCreatedAtAsc(projectId);
 
         return CommonResponse.success(
-                messages.stream().map(MessageResponseDto::new).toList()
+                messageResponseDtos
         );
     }
 

--- a/src/main/java/com/hotsix/server/message/controller/MessageController.java
+++ b/src/main/java/com/hotsix/server/message/controller/MessageController.java
@@ -25,10 +25,8 @@ public class MessageController {
     public CommonResponse<List<MessageResponseDto>> getMessagesByProjectId(
             @PathVariable long projectId
     ) {
-        List<MessageResponseDto> messageResponseDtos = messageService.findByProjectIdOrderByCreatedAtAsc(projectId);
-
         return CommonResponse.success(
-                messageResponseDtos
+                messageService.findByProjectIdOrderByCreatedAtAsc(projectId)
         );
     }
 

--- a/src/main/java/com/hotsix/server/message/service/MessageService.java
+++ b/src/main/java/com/hotsix/server/message/service/MessageService.java
@@ -32,7 +32,7 @@ public class MessageService {
                 .orElseThrow(() -> new ApplicationException(ProjectErrorCase.PROJECT_NOT_FOUND));
 
         return messageRepository.findByProjectOrderByCreatedAtAsc(project).stream()
-                .map(MessageResponseDto::new) // 여기서 Lazy 필드 접근 가능
+                .map(MessageResponseDto::new)
                 .toList();
     }
 

--- a/src/main/java/com/hotsix/server/project/entity/Project.java
+++ b/src/main/java/com/hotsix/server/project/entity/Project.java
@@ -54,5 +54,6 @@ public class Project extends BaseEntity {
     }
 
     @OneToMany(mappedBy = "project", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @Builder.Default
     private List<Message> messages = new ArrayList<>();
 }

--- a/src/main/java/com/hotsix/server/project/entity/Project.java
+++ b/src/main/java/com/hotsix/server/project/entity/Project.java
@@ -1,11 +1,14 @@
 package com.hotsix.server.project.entity;
 
 import com.hotsix.server.global.entity.BaseEntity;
+import com.hotsix.server.message.entity.Message;
 import com.hotsix.server.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -49,4 +52,7 @@ public class Project extends BaseEntity {
         }
         this.status = newStatus;
     }
+
+    @OneToMany(mappedBy = "project", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Message> messages = new ArrayList<>();
 }

--- a/src/main/java/com/hotsix/server/proposal/controller/ProposalController.java
+++ b/src/main/java/com/hotsix/server/proposal/controller/ProposalController.java
@@ -5,7 +5,6 @@ import com.hotsix.server.proposal.dto.ProposalRequestBody;
 import com.hotsix.server.proposal.dto.ProposalRequestDto;
 import com.hotsix.server.proposal.dto.ProposalResponseDto;
 import com.hotsix.server.proposal.dto.ProposalStatusRequestBody;
-import com.hotsix.server.proposal.entity.Proposal;
 import com.hotsix.server.proposal.entity.ProposalStatus;
 import com.hotsix.server.proposal.service.ProposalService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -26,10 +25,8 @@ public class ProposalController {
     @GetMapping
     @Operation(summary = "제안서 다건 조회")
     public CommonResponse<List<ProposalResponseDto>> getProposals() {
-        List<Proposal> items = proposalService.getList();
-
         return CommonResponse.success(
-                items.stream().map(ProposalResponseDto::new).toList()
+                proposalService.getList()
         );
     }
 
@@ -38,10 +35,10 @@ public class ProposalController {
     public CommonResponse<ProposalResponseDto> getProposal(
             @PathVariable long id
     ) {
-        Proposal proposal = proposalService.findById(id);
+        ProposalResponseDto proposalResponseDto = proposalService.findById(id);
 
         return CommonResponse.success(
-                new ProposalResponseDto(proposal)
+                proposalResponseDto
         );
     }
 
@@ -52,7 +49,7 @@ public class ProposalController {
             //@RequestPart(value = "files", required = false) List<ProposalFile> files
     ){
 
-        Proposal proposal = proposalService.create(
+        ProposalResponseDto proposalResponseDto = proposalService.create(
                 proposalRequestDto.projectId(),
                 proposalRequestDto.description(),
                 proposalRequestDto.proposedAmount(),
@@ -61,7 +58,7 @@ public class ProposalController {
         );
 
         return CommonResponse.success(
-                new ProposalResponseDto(proposal)
+                proposalResponseDto
         );
     }
 
@@ -70,9 +67,7 @@ public class ProposalController {
     public CommonResponse<ProposalResponseDto> deleteProposal(
             @PathVariable long id
     ){
-        ProposalResponseDto proposalResponseDto = proposalService.delete(id);
-
-        return CommonResponse.success(proposalResponseDto);
+        return CommonResponse.success(proposalService.delete(id));
     }
 
     @PutMapping("/{id}")

--- a/src/main/java/com/hotsix/server/proposal/controller/ProposalController.java
+++ b/src/main/java/com/hotsix/server/proposal/controller/ProposalController.java
@@ -90,10 +90,10 @@ public class ProposalController {
     @Operation(summary = "제안서 상태 변경")
     public CommonResponse<String> updateStatus(
             @PathVariable long id,
-            @RequestBody ProposalStatusRequestBody requestBody
+            @Valid @RequestBody ProposalStatusRequestBody requestBody
     ){
         proposalService.update(id, requestBody.proposalStatus());
-        return CommonResponse.success("%d 번 제안서가 %s 되었습니다."
+        return CommonResponse.success("%d 번 제안서의 상태가 %s로 변경되었습니다."
                 .formatted(id, requestBody.proposalStatus()));
     }
 

--- a/src/main/java/com/hotsix/server/proposal/entity/ProposalStatus.java
+++ b/src/main/java/com/hotsix/server/proposal/entity/ProposalStatus.java
@@ -1,6 +1,6 @@
 package com.hotsix.server.proposal.entity;
 
 public enum ProposalStatus {
-    DRAFT, SUBMITTED, ACCEPTED, REJECTED
-    // 프로젝트 제안 상태 관련 (작성중, 제출됨, 수락됨, 거절됨)
+    DRAFT, SUBMITTED, ACCEPTED, REJECTED, PROJECT_DELETED
+    // 프로젝트 제안 상태 관련 (작성중, 제출됨, 수락됨, 거절됨, 프로젝트 삭제됨)
 }

--- a/src/main/java/com/hotsix/server/proposal/service/ProposalService.java
+++ b/src/main/java/com/hotsix/server/proposal/service/ProposalService.java
@@ -24,18 +24,23 @@ public class ProposalService {
     private final ProjectService projectService;
 
     @Transactional(readOnly = true)
-    public List<Proposal> getList() {
-        return proposalRepository.findAll();
+    public List<ProposalResponseDto> getList() {
+
+        List<Proposal> proposals = proposalRepository.findAll();
+        return proposals.stream().map(ProposalResponseDto::new).toList();
     }
 
     @Transactional(readOnly = true)
-    public Proposal findById(long id) {
-        return proposalRepository.findById(id)
+    public ProposalResponseDto findById(long id) {
+
+        Proposal proposal = proposalRepository.findById(id)
                 .orElseThrow(() -> new ApplicationException(ProposalErrorCase.PROPOSAL_NOT_FOUND));
+
+        return new ProposalResponseDto(proposal);
     }
 
     @Transactional
-    public Proposal create(Long projectId, String description, Integer proposedAmount, /*List<ProposalFile> proposalFiles,*/ ProposalStatus proposalStatus) {
+    public ProposalResponseDto create(Long projectId, String description, Integer proposedAmount, /*List<ProposalFile> proposalFiles,*/ ProposalStatus proposalStatus) {
 
         Project project = projectService.findById(projectId);
 
@@ -50,12 +55,13 @@ public class ProposalService {
                 .proposalStatus(proposalStatus)
                 .build();
 
-        return proposalRepository.save(proposal);
+        return new ProposalResponseDto(proposalRepository.save(proposal));
     }
 
     @Transactional
     public ProposalResponseDto delete(long id) {
-        Proposal proposal = findById(id);
+        Proposal proposal = proposalRepository.findById(id)
+                .orElseThrow(() -> new ApplicationException(ProposalErrorCase.PROPOSAL_NOT_FOUND));
 
         User actor = rq.getUser();
 
@@ -69,7 +75,8 @@ public class ProposalService {
 
     @Transactional
     public void update(long id, String description, Integer proposedAmount/*, List<ProposalFile> proposalFiles*/) {
-        Proposal proposal = findById(id);
+        Proposal proposal = proposalRepository.findById(id)
+                .orElseThrow(() -> new ApplicationException(ProposalErrorCase.PROPOSAL_NOT_FOUND));
         User actor = rq.getUser();
         proposal.checkCanModify(actor);
         proposal.modify(description, proposedAmount/*, proposalFiles*/);
@@ -77,7 +84,8 @@ public class ProposalService {
 
     @Transactional
     public void update(long id, ProposalStatus proposalStatus) {
-        Proposal proposal = findById(id);
+        Proposal proposal = proposalRepository.findById(id)
+                .orElseThrow(() -> new ApplicationException(ProposalErrorCase.PROPOSAL_NOT_FOUND));
 
         User actor = rq.getUser();
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #26 

## 📝 작업 내용

> 메세지 서비스에 Transaction 어노테이션을 붙이지 않아 api가 정상작동하지 않아 수정하였습니다.

## 🖼️ 스크린샷 (선택)

> UI 변경 등 시각적으로 확인할 수 있는 내용이 있다면 첨부해주세요

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 제안서 상태에 “프로젝트 삭제됨”이 추가되어 상태 관리 범위가 확대되었습니다.
  - 프로젝트 삭제 시 연관된 메시지가 함께 삭제되도록 연관 관계가 추가되었습니다.
  - 제안서 상태 변경 요청에 유효성 검사(@Valid)가 적용되었습니다.
- 리팩터링
  - 메시지와 제안서 API가 응답용 DTO를 직접 반환하여 응답 일관성과 효율성이 향상되었습니다.
- 스타일
  - 제안서 상태 변경 알림 문구가 더 명확한 표현으로 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->