### PR TITLE
[feat] SSE통신 및 채팅방 구현

### DIFF
--- a/src/main/java/com/hotsix/server/auth/controller/AuthController.java
+++ b/src/main/java/com/hotsix/server/auth/controller/AuthController.java
@@ -109,5 +109,4 @@ public class AuthController {
                 response
         );
     }
-
 }

--- a/src/main/java/com/hotsix/server/message/controller/ChatRoomController.java
+++ b/src/main/java/com/hotsix/server/message/controller/ChatRoomController.java
@@ -30,9 +30,9 @@ public class ChatRoomController {
     @GetMapping()
     @Operation(summary = "내 채팅방 목록 조회")
     public CommonResponse<List<ChatRoomResponseDto>> getChatRooms() {
-        List<ChatRoom> rooms = chatRoomService.getChatRoomsByUser();
+        List<ChatRoomResponseDto> chatRoomResponseDtos = chatRoomService.getChatRoomsByUser();
         return CommonResponse.success(
-                rooms.stream().map(ChatRoomResponseDto::new).toList()
+                chatRoomResponseDtos
         );
     }
     // 채팅방 참가

--- a/src/main/java/com/hotsix/server/message/controller/ChatRoomController.java
+++ b/src/main/java/com/hotsix/server/message/controller/ChatRoomController.java
@@ -1,0 +1,45 @@
+package com.hotsix.server.message.controller;
+
+import com.hotsix.server.global.response.CommonResponse;
+import com.hotsix.server.message.dto.ChatRoomCreateRequestDto;
+import com.hotsix.server.message.dto.ChatRoomResponseDto;
+import com.hotsix.server.message.entity.ChatRoom;
+import com.hotsix.server.message.service.ChatRoomService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/chatrooms")
+@RequiredArgsConstructor
+@Tag(name = "ChatRoomController", description = "API 채팅방 컨트롤러")
+public class ChatRoomController {
+
+    private final ChatRoomService chatRoomService;
+
+    @PostMapping
+    @Operation(summary = "채팅방 생성")
+    public CommonResponse<ChatRoomResponseDto> createRoom(@RequestBody ChatRoomCreateRequestDto dto) {
+        ChatRoom room = chatRoomService.createRoom(dto.title());
+        return CommonResponse.success(new ChatRoomResponseDto(room));
+    }
+
+    @GetMapping()
+    @Operation(summary = "내 채팅방 목록 조회")
+    public CommonResponse<List<ChatRoomResponseDto>> getChatRooms() {
+        List<ChatRoom> rooms = chatRoomService.getChatRoomsByUser();
+        return CommonResponse.success(
+                rooms.stream().map(ChatRoomResponseDto::new).toList()
+        );
+    }
+    // 채팅방 참가
+    @PostMapping("/{chatRoomId}/join")
+    @Operation(summary = "채팅방 참가")
+    public CommonResponse<String> joinRoom(@PathVariable Long chatRoomId) {
+        chatRoomService.joinRoom(chatRoomId);
+        return CommonResponse.success("채팅방에 참가했습니다.");
+    }
+}

--- a/src/main/java/com/hotsix/server/message/controller/MessageController.java
+++ b/src/main/java/com/hotsix/server/message/controller/MessageController.java
@@ -19,13 +19,13 @@ public class MessageController {
 
     private final MessageService messageService;
 
-    @GetMapping("/{projectId}")
-    @Operation(summary = "프로젝트 관련 메세지 조회")
-    public CommonResponse<List<MessageResponseDto>> getMessagesByProjectId(
-            @PathVariable long projectId
+    @GetMapping("/{chatRoomId}")
+    @Operation(summary = "채팅방 메세지 조회")
+    public CommonResponse<List<MessageResponseDto>> getMessagesByChatRoomId(
+            @PathVariable long chatRoomId
     ) {
         return CommonResponse.success(
-                messageService.findByProjectIdOrderByCreatedAtAsc(projectId)
+                messageService.findByChatRoomIdOrderByCreatedAtAsc(chatRoomId)
         );
     }
 
@@ -47,6 +47,8 @@ public class MessageController {
         MessageResponseDto message = messageService.sendMessage(dto);
         return CommonResponse.success(message);
     }
+
+
 
     // 메시지 전송, 조회 등 API 구현
 }

--- a/src/main/java/com/hotsix/server/message/controller/MessageController.java
+++ b/src/main/java/com/hotsix/server/message/controller/MessageController.java
@@ -3,7 +3,6 @@ package com.hotsix.server.message.controller;
 import com.hotsix.server.global.response.CommonResponse;
 import com.hotsix.server.message.dto.MessageRequestDto;
 import com.hotsix.server.message.dto.MessageResponseDto;
-import com.hotsix.server.message.entity.Message;
 import com.hotsix.server.message.service.MessageService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -42,17 +41,12 @@ public class MessageController {
 
     @PostMapping()
     @Operation(summary = "메세지 작성")
-    public CommonResponse<MessageResponseDto> createMessage(
-            @RequestBody MessageRequestDto messageRequestDto
-    ){
-        Message message = messageService.create(messageRequestDto);
-
-        return CommonResponse.success(
-                new MessageResponseDto(message)
-        );
+    public CommonResponse<MessageResponseDto> sendMessage(
+            @RequestBody MessageRequestDto dto
+    ) {
+        MessageResponseDto message = messageService.sendMessage(dto);
+        return CommonResponse.success(message);
     }
-
-
 
     // 메시지 전송, 조회 등 API 구현
 }

--- a/src/main/java/com/hotsix/server/message/controller/SseController.java
+++ b/src/main/java/com/hotsix/server/message/controller/SseController.java
@@ -24,7 +24,7 @@ public class SseController {
             @RequestParam Long chatRoomId
     ) {
         //1. 새로운 SseEmitter(HTTP 스트림 하나를 관리하는 객체) 객체를 생성
-        //2. emitter를 ProjectEmitterRepository에 저장
+        //2. emitter를 ChatRoomEmitterRepository에 저장
         //3. emitter의 timeout/completion 시 정리 로직 등록
         //4. 최초 연결 확인용 이벤트(connect) 전송 -> “connected : userId=1” 같은 데이터
         return sseService.connect(chatRoomId);
@@ -32,4 +32,4 @@ public class SseController {
 }
 
 //<프런트 SSE 연결 요청 코드>
-//const eventSource = new EventSource(`/api/sse/connect?projectId=1`);
+//const eventSource = new EventSource(`/api/sse/connect?chatRoomtId=1`);

--- a/src/main/java/com/hotsix/server/message/controller/SseController.java
+++ b/src/main/java/com/hotsix/server/message/controller/SseController.java
@@ -4,7 +4,6 @@ import com.hotsix.server.message.service.SseService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
-import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -22,17 +21,13 @@ public class SseController {
     //produces = MediaType.TEXT_EVENT_STREAM_VALUE => pring MVC가 응답을 text/event-stream 형식으로 보내고 HTTP 연결을 끊지 않은 채 계속 유지하게 된다.
     @GetMapping(value = "/connect", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter connect(
-            @RequestParam Long projectId,
-            Authentication authentication
+            @RequestParam Long chatRoomId
     ) {
-        Long userId = (Long) authentication.getPrincipal();
-
-
         //1. 새로운 SseEmitter(HTTP 스트림 하나를 관리하는 객체) 객체를 생성
         //2. emitter를 ProjectEmitterRepository에 저장
         //3. emitter의 timeout/completion 시 정리 로직 등록
         //4. 최초 연결 확인용 이벤트(connect) 전송 -> “connected : userId=1” 같은 데이터
-        return sseService.connect(projectId, userId);
+        return sseService.connect(chatRoomId);
     }
 }
 

--- a/src/main/java/com/hotsix/server/message/controller/SseController.java
+++ b/src/main/java/com/hotsix/server/message/controller/SseController.java
@@ -1,0 +1,40 @@
+package com.hotsix.server.message.controller;
+
+import com.hotsix.server.message.service.SseService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequestMapping("/api/sse")
+@RequiredArgsConstructor
+@Tag(name = "SseController", description = "SSE 컨트롤러")
+public class SseController {
+
+    private final SseService sseService;
+
+    //produces = MediaType.TEXT_EVENT_STREAM_VALUE => pring MVC가 응답을 text/event-stream 형식으로 보내고 HTTP 연결을 끊지 않은 채 계속 유지하게 된다.
+    @GetMapping(value = "/connect", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter connect(
+            @RequestParam Long projectId,
+            Authentication authentication
+    ) {
+        Long userId = (Long) authentication.getPrincipal();
+
+
+        //1. 새로운 SseEmitter(HTTP 스트림 하나를 관리하는 객체) 객체를 생성
+        //2. emitter를 ProjectEmitterRepository에 저장
+        //3. emitter의 timeout/completion 시 정리 로직 등록
+        //4. 최초 연결 확인용 이벤트(connect) 전송 -> “connected : userId=1” 같은 데이터
+        return sseService.connect(projectId, userId);
+    }
+}
+
+//<프런트 SSE 연결 요청 코드>
+//const eventSource = new EventSource(`/api/sse/connect?projectId=1`);

--- a/src/main/java/com/hotsix/server/message/dto/ChatRoomCreateRequestDto.java
+++ b/src/main/java/com/hotsix/server/message/dto/ChatRoomCreateRequestDto.java
@@ -1,0 +1,6 @@
+package com.hotsix.server.message.dto;
+
+
+public record ChatRoomCreateRequestDto(
+        String title
+) {}

--- a/src/main/java/com/hotsix/server/message/dto/ChatRoomResponseDto.java
+++ b/src/main/java/com/hotsix/server/message/dto/ChatRoomResponseDto.java
@@ -1,0 +1,19 @@
+package com.hotsix.server.message.dto;
+
+import com.hotsix.server.message.entity.ChatRoom;
+
+import java.time.LocalDateTime;
+
+public record ChatRoomResponseDto(
+        Long chatRoomId,
+        String title,
+        LocalDateTime createdAt
+) {
+    public ChatRoomResponseDto(ChatRoom chatRoom) {
+        this(
+                chatRoom.getChatRoomId(),
+                chatRoom.getTitle(),
+                chatRoom.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/hotsix/server/message/dto/MessageRequestDto.java
+++ b/src/main/java/com/hotsix/server/message/dto/MessageRequestDto.java
@@ -1,7 +1,7 @@
 package com.hotsix.server.message.dto;
 
 public record MessageRequestDto (
-        Long projectId,
+        Long chatRoomId,
         String content
 ){
 

--- a/src/main/java/com/hotsix/server/message/entity/ChatRoom.java
+++ b/src/main/java/com/hotsix/server/message/entity/ChatRoom.java
@@ -1,0 +1,35 @@
+package com.hotsix.server.message.entity;
+
+import com.hotsix.server.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "chat room")
+public class ChatRoom extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long chatRoomId;
+
+    private String title;
+
+    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Message> messages = new ArrayList<>();
+
+    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ChatRoomUser> participants = new ArrayList<>();
+
+    public static ChatRoom create(String title) {
+        return ChatRoom.builder()
+                .title(title)
+                .build();
+    }
+}

--- a/src/main/java/com/hotsix/server/message/entity/ChatRoom.java
+++ b/src/main/java/com/hotsix/server/message/entity/ChatRoom.java
@@ -12,7 +12,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-@Table(name = "chat room")
+@Table(name = "chat_room")
 public class ChatRoom extends BaseEntity {
 
     @Id
@@ -21,9 +21,11 @@ public class ChatRoom extends BaseEntity {
 
     private String title;
 
+    @Builder.Default
     @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Message> messages = new ArrayList<>();
 
+    @Builder.Default
     @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ChatRoomUser> participants = new ArrayList<>();
 

--- a/src/main/java/com/hotsix/server/message/entity/ChatRoomUser.java
+++ b/src/main/java/com/hotsix/server/message/entity/ChatRoomUser.java
@@ -1,0 +1,37 @@
+package com.hotsix.server.message.entity;
+
+import com.hotsix.server.global.entity.BaseEntity;
+import com.hotsix.server.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "chat_room_user")
+public class ChatRoomUser extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long chatRoomUserid;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id")
+    private ChatRoom chatRoom;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    public static ChatRoomUser create(ChatRoom chatRoom, User user) {
+        return ChatRoomUser.builder()
+                .chatRoom(chatRoom)
+                .user(user)
+                .build();
+    }
+}

--- a/src/main/java/com/hotsix/server/message/entity/ChatRoomUser.java
+++ b/src/main/java/com/hotsix/server/message/entity/ChatRoomUser.java
@@ -18,7 +18,7 @@ public class ChatRoomUser extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long chatRoomUserid;
+    private Long chatRoomUserId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "chat_room_id")

--- a/src/main/java/com/hotsix/server/message/entity/Message.java
+++ b/src/main/java/com/hotsix/server/message/entity/Message.java
@@ -1,7 +1,6 @@
 package com.hotsix.server.message.entity;
 
 import com.hotsix.server.global.entity.BaseEntity;
-import com.hotsix.server.project.entity.Project;
 import com.hotsix.server.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
@@ -19,8 +18,8 @@ public class Message extends BaseEntity {
     private Long messageId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "project_id", nullable = false)
-    private Project project;
+    @JoinColumn(name = "chat_room_id")
+    private ChatRoom chatRoom;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sender_user_id", referencedColumnName = "userId", nullable = false)

--- a/src/main/java/com/hotsix/server/message/entity/Message.java
+++ b/src/main/java/com/hotsix/server/message/entity/Message.java
@@ -18,7 +18,7 @@ public class Message extends BaseEntity {
     private Long messageId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "chat_room_id")
+    @JoinColumn(name = "chat_room_id", nullable = false)
     private ChatRoom chatRoom;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/hotsix/server/message/exception/ChatRoomErrorCase.java
+++ b/src/main/java/com/hotsix/server/message/exception/ChatRoomErrorCase.java
@@ -9,7 +9,8 @@ import lombok.RequiredArgsConstructor;
 public enum ChatRoomErrorCase implements ErrorCase {
 
     CHAT_ROOM_NOT_FOUND(404, 8101, "존재하지 않는 채팅방입니다."),
-    ALREADY_JOINED(409, 8102, "이미 참가 중인 채팅방입니다.");
+    ALREADY_JOINED(409, 8102, "이미 참가 중인 채팅방입니다."),
+    FORBIDDEN_ACCESS(403,8103 , "접근할 수 없는 채팅방입니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/hotsix/server/message/exception/ChatRoomErrorCase.java
+++ b/src/main/java/com/hotsix/server/message/exception/ChatRoomErrorCase.java
@@ -1,0 +1,16 @@
+package com.hotsix.server.message.exception;
+
+import com.hotsix.server.global.exception.ErrorCase;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ChatRoomErrorCase implements ErrorCase {
+
+    CHAT_ROOM_NOT_FOUND(404, 8101, "메시지를 찾을 수 없습니다.");
+
+    private final Integer httpStatusCode;
+    private final Integer errorCode;
+    private final String message;
+}

--- a/src/main/java/com/hotsix/server/message/exception/ChatRoomErrorCase.java
+++ b/src/main/java/com/hotsix/server/message/exception/ChatRoomErrorCase.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ChatRoomErrorCase implements ErrorCase {
 
-    CHAT_ROOM_NOT_FOUND(404, 8101, "메시지를 찾을 수 없습니다.");
+    CHAT_ROOM_NOT_FOUND(404, 8101, "존재하지 않는 채팅방입니다."),
+    ALREADY_JOINED(409, 8102, "이미 참가 중인 채팅방입니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/src/main/java/com/hotsix/server/message/repository/ChatRoomRepository.java
+++ b/src/main/java/com/hotsix/server/message/repository/ChatRoomRepository.java
@@ -1,0 +1,7 @@
+package com.hotsix.server.message.repository;
+
+import com.hotsix.server.message.entity.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+}

--- a/src/main/java/com/hotsix/server/message/repository/ChatRoomUserRepository.java
+++ b/src/main/java/com/hotsix/server/message/repository/ChatRoomUserRepository.java
@@ -8,6 +8,6 @@ import java.util.List;
 
 @Repository
 public interface ChatRoomUserRepository extends JpaRepository<ChatRoomUser, Long> {
-    List<ChatRoomUser> findByUserId(Long userId);
-    boolean existsByUserIdAndChatRoomId(Long userId, Long chatRoomId);
+    List<ChatRoomUser> findByUser_UserId(Long userId);
+    boolean existsByUser_UserIdAndChatRoom_ChatRoomId(Long userId, Long chatRoomId);
 }

--- a/src/main/java/com/hotsix/server/message/repository/ChatRoomUserRepository.java
+++ b/src/main/java/com/hotsix/server/message/repository/ChatRoomUserRepository.java
@@ -1,0 +1,13 @@
+package com.hotsix.server.message.repository;
+
+import com.hotsix.server.message.entity.ChatRoomUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ChatRoomUserRepository extends JpaRepository<ChatRoomUser, Long> {
+    List<ChatRoomUser> findByUserId(Long userId);
+    boolean existsByUserIdAndChatRoomId(Long userId, Long chatRoomId);
+}

--- a/src/main/java/com/hotsix/server/message/repository/MessageRepository.java
+++ b/src/main/java/com/hotsix/server/message/repository/MessageRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface MessageRepository extends JpaRepository<Message, Long> {
-    List<Message> findByChatRoomIdOrderByCreatedAtAsc(Long chatRoomId);
+    List<Message> findByChatRoom_ChatRoomIdOrderByCreatedAtAsc(Long chatRoomId);
 }

--- a/src/main/java/com/hotsix/server/message/repository/MessageRepository.java
+++ b/src/main/java/com/hotsix/server/message/repository/MessageRepository.java
@@ -1,11 +1,10 @@
 package com.hotsix.server.message.repository;
 
 import com.hotsix.server.message.entity.Message;
-import com.hotsix.server.project.entity.Project;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface MessageRepository extends JpaRepository<Message, Long> {
-    List<Message> findByProjectOrderByCreatedAtAsc(Project project);
+    List<Message> findByChatRoomIdOrderByCreatedAtAsc(Long chatRoomId);
 }

--- a/src/main/java/com/hotsix/server/message/service/ChatRoomService.java
+++ b/src/main/java/com/hotsix/server/message/service/ChatRoomService.java
@@ -1,9 +1,11 @@
 package com.hotsix.server.message.service;
 
 import com.hotsix.server.global.Rq.Rq;
+import com.hotsix.server.global.exception.ApplicationException;
 import com.hotsix.server.message.dto.ChatRoomResponseDto;
 import com.hotsix.server.message.entity.ChatRoom;
 import com.hotsix.server.message.entity.ChatRoomUser;
+import com.hotsix.server.message.exception.ChatRoomErrorCase;
 import com.hotsix.server.message.repository.ChatRoomRepository;
 import com.hotsix.server.message.repository.ChatRoomUserRepository;
 import com.hotsix.server.user.entity.User;
@@ -54,9 +56,9 @@ public class ChatRoomService {
         User user = rq.getUser();
 
         ChatRoom room = chatRoomRepository.findById(chatRoomId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 채팅방입니다."));
+                .orElseThrow(() -> new ApplicationException(ChatRoomErrorCase.CHAT_ROOM_NOT_FOUND));
         if (chatRoomUserRepository.existsByUser_UserIdAndChatRoom_ChatRoomId(user.getUserId(), chatRoomId)) {
-            throw new IllegalStateException("이미 참가 중인 채팅방입니다.");
+            throw new ApplicationException(ChatRoomErrorCase.ALREADY_JOINED);
         }
         chatRoomUserRepository.save(ChatRoomUser.create(room, user));
     }

--- a/src/main/java/com/hotsix/server/message/service/ChatRoomService.java
+++ b/src/main/java/com/hotsix/server/message/service/ChatRoomService.java
@@ -1,6 +1,7 @@
 package com.hotsix.server.message.service;
 
 import com.hotsix.server.global.Rq.Rq;
+import com.hotsix.server.message.dto.ChatRoomResponseDto;
 import com.hotsix.server.message.entity.ChatRoom;
 import com.hotsix.server.message.entity.ChatRoomUser;
 import com.hotsix.server.message.repository.ChatRoomRepository;
@@ -34,11 +35,15 @@ public class ChatRoomService {
     }
 
     @Transactional
-    public List<ChatRoom> getChatRoomsByUser() {
+    public List<ChatRoomResponseDto> getChatRoomsByUser() {
         User user = rq.getUser();
-        List<ChatRoomUser> relations = chatRoomUserRepository.findByUserId(user.getUserId());
-        return relations.stream()
+        List<ChatRoomUser> relations = chatRoomUserRepository.findByUser_UserId(user.getUserId());
+        List<ChatRoom> chatRooms =  relations.stream()
                 .map(ChatRoomUser::getChatRoom)
+                .toList();
+
+        return chatRooms.stream()
+                .map(ChatRoomResponseDto::new)
                 .toList();
     }
 
@@ -50,7 +55,7 @@ public class ChatRoomService {
 
         ChatRoom room = chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 채팅방입니다."));
-        if (chatRoomUserRepository.existsByUserIdAndChatRoomId(user.getUserId(), chatRoomId)) {
+        if (chatRoomUserRepository.existsByUser_UserIdAndChatRoom_ChatRoomId(user.getUserId(), chatRoomId)) {
             throw new IllegalStateException("이미 참가 중인 채팅방입니다.");
         }
         chatRoomUserRepository.save(ChatRoomUser.create(room, user));

--- a/src/main/java/com/hotsix/server/message/service/ChatRoomService.java
+++ b/src/main/java/com/hotsix/server/message/service/ChatRoomService.java
@@ -1,0 +1,58 @@
+package com.hotsix.server.message.service;
+
+import com.hotsix.server.global.Rq.Rq;
+import com.hotsix.server.message.entity.ChatRoom;
+import com.hotsix.server.message.entity.ChatRoomUser;
+import com.hotsix.server.message.repository.ChatRoomRepository;
+import com.hotsix.server.message.repository.ChatRoomUserRepository;
+import com.hotsix.server.user.entity.User;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ChatRoomService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatRoomUserRepository chatRoomUserRepository;
+    private final Rq rq;
+
+    @Transactional
+    public ChatRoom createRoom(String name) {
+        ChatRoom chatRoom = ChatRoom.create(name);
+        chatRoomRepository.save(chatRoom);
+
+        User creator = rq.getUser();
+
+        ChatRoomUser relation = ChatRoomUser.create(chatRoom, creator);
+        chatRoomUserRepository.save(relation);
+
+        return chatRoom;
+    }
+
+    @Transactional
+    public List<ChatRoom> getChatRoomsByUser() {
+        User user = rq.getUser();
+        List<ChatRoomUser> relations = chatRoomUserRepository.findByUserId(user.getUserId());
+        return relations.stream()
+                .map(ChatRoomUser::getChatRoom)
+                .toList();
+    }
+
+    // 특정 채팅방에 유저 추가
+    @Transactional
+    public void joinRoom(Long chatRoomId) {
+
+        User user = rq.getUser();
+
+        ChatRoom room = chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 채팅방입니다."));
+        if (chatRoomUserRepository.existsByUserIdAndChatRoomId(user.getUserId(), chatRoomId)) {
+            throw new IllegalStateException("이미 참가 중인 채팅방입니다.");
+        }
+        chatRoomUserRepository.save(ChatRoomUser.create(room, user));
+    }
+}

--- a/src/main/java/com/hotsix/server/message/service/MessageService.java
+++ b/src/main/java/com/hotsix/server/message/service/MessageService.java
@@ -36,7 +36,7 @@ public class MessageService {
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(() -> new ApplicationException(ChatRoomErrorCase.CHAT_ROOM_NOT_FOUND));
 
-        return messageRepository.findByChatRoomIdOrderByCreatedAtAsc(chatRoomId).stream()
+        return messageRepository.findByChatRoom_ChatRoomIdOrderByCreatedAtAsc(chatRoomId).stream()
                 .map(MessageResponseDto::new)
                 .toList();
     }

--- a/src/main/java/com/hotsix/server/message/service/SseService.java
+++ b/src/main/java/com/hotsix/server/message/service/SseService.java
@@ -36,7 +36,7 @@ public class SseService {
         return emitter;
     }
 
-    public void removeEmitter(Long projectId, SseEmitter emitter) {
-        emitterRepository.remove(projectId, emitter);
+    public void removeEmitter(Long chatRoomId, SseEmitter emitter) {
+        emitterRepository.remove(chatRoomId, emitter);
     }
 }

--- a/src/main/java/com/hotsix/server/message/service/SseService.java
+++ b/src/main/java/com/hotsix/server/message/service/SseService.java
@@ -1,0 +1,46 @@
+package com.hotsix.server.message.service;
+
+import com.hotsix.server.message.sse.ProjectEmitterRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SseService {
+
+    private final ProjectEmitterRepository emitterRepository;
+
+    public SseEmitter connect(Long projectId, Long userId) {
+
+        //이 emitter가 '이 클라이언트의 실시간 통신 라인' 이 된다.
+        SseEmitter emitter = new SseEmitter(30 * 60 * 1000L); // 30분 유지
+        emitterRepository.save(projectId, emitter);
+
+        // 연결 종료 / 타임아웃 처리
+        emitter.onCompletion(() -> emitterRepository.remove(projectId, emitter));
+        emitter.onTimeout(() -> emitterRepository.remove(projectId, emitter));
+
+        try {
+            emitter.send(SseEmitter.event()
+                    .name("connect")
+                    .data("connected : userId=" + userId));
+        } catch (IOException e) {
+            emitterRepository.remove(projectId, emitter);
+        }
+
+        return emitter;
+    }
+
+    //실시간 메시지를 broadcast 하는 시점에서 호출됨
+    public List<SseEmitter> getEmitters(Long projectId) {
+        return emitterRepository.findAllByProjectId(projectId);
+    }
+
+    public void removeEmitter(Long projectId, SseEmitter emitter) {
+        emitterRepository.remove(projectId, emitter);
+    }
+}

--- a/src/main/java/com/hotsix/server/message/service/SseService.java
+++ b/src/main/java/com/hotsix/server/message/service/SseService.java
@@ -1,43 +1,39 @@
 package com.hotsix.server.message.service;
 
-import com.hotsix.server.message.sse.ProjectEmitterRepository;
+import com.hotsix.server.global.Rq.Rq;
+import com.hotsix.server.message.sse.ChatRoomEmitterRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class SseService {
 
-    private final ProjectEmitterRepository emitterRepository;
+    private final ChatRoomEmitterRepository emitterRepository;
+    private final Rq rq;
 
-    public SseEmitter connect(Long projectId, Long userId) {
+    public SseEmitter connect(Long chatRoomId) {
 
         //이 emitter가 '이 클라이언트의 실시간 통신 라인' 이 된다.
         SseEmitter emitter = new SseEmitter(30 * 60 * 1000L); // 30분 유지
-        emitterRepository.save(projectId, emitter);
+        emitterRepository.save(chatRoomId, emitter);
 
         // 연결 종료 / 타임아웃 처리
-        emitter.onCompletion(() -> emitterRepository.remove(projectId, emitter));
-        emitter.onTimeout(() -> emitterRepository.remove(projectId, emitter));
+        emitter.onCompletion(() -> emitterRepository.remove(chatRoomId, emitter));
+        emitter.onTimeout(() -> emitterRepository.remove(chatRoomId, emitter));
 
         try {
             emitter.send(SseEmitter.event()
                     .name("connect")
-                    .data("connected : userId=" + userId));
+                    .data("connected : userId=" + rq.getUser()));
         } catch (IOException e) {
-            emitterRepository.remove(projectId, emitter);
+            emitterRepository.remove(chatRoomId, emitter);
         }
 
         return emitter;
-    }
-
-    //실시간 메시지를 broadcast 하는 시점에서 호출됨
-    public List<SseEmitter> getEmitters(Long projectId) {
-        return emitterRepository.findAllByProjectId(projectId);
     }
 
     public void removeEmitter(Long projectId, SseEmitter emitter) {

--- a/src/main/java/com/hotsix/server/message/sse/ChatRoomEmitterRepository.java
+++ b/src/main/java/com/hotsix/server/message/sse/ChatRoomEmitterRepository.java
@@ -3,19 +3,18 @@ package com.hotsix.server.message.sse;
 import org.springframework.stereotype.Repository;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 @Repository
 public class ChatRoomEmitterRepository {
 
-    private final Map<Long, List<SseEmitter>> emitters = new ConcurrentHashMap<>();
+    private final Map<Long, CopyOnWriteArrayList<SseEmitter>> emitters = new ConcurrentHashMap<>();
 
     public SseEmitter save(Long chatRoomId, SseEmitter emitter) {
-        emitters.computeIfAbsent(chatRoomId, k -> new ArrayList<>()).add(emitter);
+        emitters.computeIfAbsent(chatRoomId, k -> new CopyOnWriteArrayList<>()).add(emitter);
         return emitter;
     }
 
@@ -25,7 +24,7 @@ public class ChatRoomEmitterRepository {
     }
 
     public List<SseEmitter> findAllByChatRoomId(Long chatRoomId) {
-        return emitters.getOrDefault(chatRoomId, Collections.emptyList());
+        return emitters.getOrDefault(chatRoomId, new CopyOnWriteArrayList<>());
     }
 
 }

--- a/src/main/java/com/hotsix/server/message/sse/ChatRoomEmitterRepository.java
+++ b/src/main/java/com/hotsix/server/message/sse/ChatRoomEmitterRepository.java
@@ -10,21 +10,22 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Repository
-public class ProjectEmitterRepository {
+public class ChatRoomEmitterRepository {
 
     private final Map<Long, List<SseEmitter>> emitters = new ConcurrentHashMap<>();
 
-    public SseEmitter save(Long projectId, SseEmitter emitter) {
-        emitters.computeIfAbsent(projectId, k -> new ArrayList<>()).add(emitter);
+    public SseEmitter save(Long chatRoomId, SseEmitter emitter) {
+        emitters.computeIfAbsent(chatRoomId, k -> new ArrayList<>()).add(emitter);
         return emitter;
     }
 
-    public void remove(Long projectId, SseEmitter emitter) {
-        List<SseEmitter> list = emitters.get(projectId);
+    public void remove(Long chatRoomId, SseEmitter emitter) {
+        List<SseEmitter> list = emitters.get(chatRoomId);
         if (list != null) list.remove(emitter);
     }
 
-    public List<SseEmitter> findAllByProjectId(Long projectId) {
-        return emitters.getOrDefault(projectId, Collections.emptyList());
+    public List<SseEmitter> findAllByChatRoomId(Long chatRoomId) {
+        return emitters.getOrDefault(chatRoomId, Collections.emptyList());
     }
+
 }

--- a/src/main/java/com/hotsix/server/message/sse/ProjectEmitterRepository.java
+++ b/src/main/java/com/hotsix/server/message/sse/ProjectEmitterRepository.java
@@ -1,0 +1,30 @@
+package com.hotsix.server.message.sse;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Repository
+public class ProjectEmitterRepository {
+
+    private final Map<Long, List<SseEmitter>> emitters = new ConcurrentHashMap<>();
+
+    public SseEmitter save(Long projectId, SseEmitter emitter) {
+        emitters.computeIfAbsent(projectId, k -> new ArrayList<>()).add(emitter);
+        return emitter;
+    }
+
+    public void remove(Long projectId, SseEmitter emitter) {
+        List<SseEmitter> list = emitters.get(projectId);
+        if (list != null) list.remove(emitter);
+    }
+
+    public List<SseEmitter> findAllByProjectId(Long projectId) {
+        return emitters.getOrDefault(projectId, Collections.emptyList());
+    }
+}

--- a/src/main/java/com/hotsix/server/project/entity/Project.java
+++ b/src/main/java/com/hotsix/server/project/entity/Project.java
@@ -1,14 +1,11 @@
 package com.hotsix.server.project.entity;
 
 import com.hotsix.server.global.entity.BaseEntity;
-import com.hotsix.server.message.entity.Message;
 import com.hotsix.server.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -52,8 +49,4 @@ public class Project extends BaseEntity {
         }
         this.status = newStatus;
     }
-
-    @OneToMany(mappedBy = "project", cascade = CascadeType.REMOVE, orphanRemoval = true)
-    @Builder.Default
-    private List<Message> messages = new ArrayList<>();
 }

--- a/src/main/java/com/hotsix/server/proposal/controller/ProposalController.java
+++ b/src/main/java/com/hotsix/server/proposal/controller/ProposalController.java
@@ -30,12 +30,12 @@ public class ProposalController {
         );
     }
 
-    @GetMapping("/{id}")
+    @GetMapping("/{proposalId}")
     @Operation(summary = "제안서 단건 조회")
     public CommonResponse<ProposalResponseDto> getProposal(
-            @PathVariable long id
+            @PathVariable long proposalId
     ) {
-        ProposalResponseDto proposalResponseDto = proposalService.findById(id);
+        ProposalResponseDto proposalResponseDto = proposalService.findById(proposalId);
 
         return CommonResponse.success(
                 proposalResponseDto
@@ -62,34 +62,34 @@ public class ProposalController {
         );
     }
 
-    @DeleteMapping("/{id}")
-    @Operation(summary = "삭제")
+    @DeleteMapping("/{proposalId}")
+    @Operation(summary = "제안서 삭제")
     public CommonResponse<ProposalResponseDto> deleteProposal(
-            @PathVariable long id
+            @PathVariable long proposalId
     ){
-        return CommonResponse.success(proposalService.delete(id));
+        return CommonResponse.success(proposalService.delete(proposalId));
     }
 
-    @PutMapping("/{id}")
-    @Operation(summary = "수정")
+    @PutMapping("/{proposalId}")
+    @Operation(summary = "제안서 수정")
     public CommonResponse<String> updateProposal(
-            @PathVariable long id,
+            @PathVariable long proposalId,
             @Valid @RequestBody ProposalRequestBody requestBody
     ){
-        proposalService.update(id, requestBody.description(), requestBody.proposedAmount()/*, requestBody.portfolioFiles()*/);
+        proposalService.update(proposalId, requestBody.description(), requestBody.proposedAmount()/*, requestBody.portfolioFiles()*/);
 
-        return CommonResponse.success("%d번 제안서가 수정되었습니다.".formatted(id));
+        return CommonResponse.success("%d번 제안서가 수정되었습니다.".formatted(proposalId));
     }
 
-    @PutMapping("/{id}/status")
+    @PutMapping("/{proposalId}/status")
     @Operation(summary = "제안서 상태 변경")
     public CommonResponse<String> updateStatus(
-            @PathVariable long id,
+            @PathVariable long proposalId,
             @Valid @RequestBody ProposalStatusRequestBody requestBody
     ){
-        proposalService.update(id, requestBody.proposalStatus());
+        proposalService.update(proposalId, requestBody.proposalStatus());
         return CommonResponse.success("%d 번 제안서의 상태가 %s로 변경되었습니다."
-                .formatted(id, requestBody.proposalStatus()));
+                .formatted(proposalId, requestBody.proposalStatus()));
     }
 
 }

--- a/src/main/java/com/hotsix/server/proposal/controller/ProposalController.java
+++ b/src/main/java/com/hotsix/server/proposal/controller/ProposalController.java
@@ -70,7 +70,7 @@ public class ProposalController {
         return CommonResponse.success(proposalService.delete(proposalId));
     }
 
-    @PutMapping("/{proposalId}")
+    @PatchMapping("/{proposalId}")
     @Operation(summary = "제안서 수정")
     public CommonResponse<String> updateProposal(
             @PathVariable long proposalId,
@@ -81,7 +81,7 @@ public class ProposalController {
         return CommonResponse.success("%d번 제안서가 수정되었습니다.".formatted(proposalId));
     }
 
-    @PutMapping("/{proposalId}/status")
+    @PatchMapping("/{proposalId}/status")
     @Operation(summary = "제안서 상태 변경")
     public CommonResponse<String> updateStatus(
             @PathVariable long proposalId,

--- a/src/main/java/com/hotsix/server/user/entity/User.java
+++ b/src/main/java/com/hotsix/server/user/entity/User.java
@@ -1,11 +1,14 @@
 package com.hotsix.server.user.entity;
 
 import com.hotsix.server.global.entity.BaseEntity;
+import com.hotsix.server.message.entity.ChatRoomUser;
 import com.hotsix.server.profile.entity.Profile;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Getter
@@ -48,6 +51,10 @@ public class User extends BaseEntity {
     private String providerId;
 
     private String picture;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ChatRoomUser> chatRooms = new ArrayList<>();
+
 
     public User(String email,
                 String password,


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #26 

## 📝 작업 내용

> SSE 통신 구현하였습니다
> 메세지 기능에 채팅방 기능을 구현하였습니다. 
> Swagger상에서는 정상 작동하는 것 확인했습니다. 다만, SSE 통신의 경우 확인이 어려워 프런트에서 확인해봐야 할 것 같습니다.

## 🖼️ 스크린샷 (선택)

> UI 변경 등 시각적으로 확인할 수 있는 내용이 있다면 첨부해주세요

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 채팅방 기능 추가: 생성, 내 채팅방 목록 조회, 채팅방 참여
  - 실시간 메시지 수신을 위한 SSE 연결 지원 및 서버 푸시(연결 유지/해제 관리)

- Changes
  - 메시지 흐름을 프로젝트 기준에서 채팅방 기준으로 전환(경로/파라미터 chatRoomId, 전송 메서드명 sendMessage)
  - 사용자-채팅방 가입/권한 검증 추가
  - 제안서 경로 변수명을 proposalId로 통일 및 일부 업데이트를 PATCH로 전환

- Bug Fixes
  - 인증 처리 코드의 불필요한 문법 오류 수정 (안정성 개선)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->