### PR TITLE
[feat] 제안서 등록시 파일 업로드 기능 구현

### DIFF
--- a/src/main/java/com/hotsix/server/message/controller/ChatRoomController.java
+++ b/src/main/java/com/hotsix/server/message/controller/ChatRoomController.java
@@ -27,7 +27,7 @@ public class ChatRoomController {
         return CommonResponse.success(new ChatRoomResponseDto(room));
     }
 
-    @GetMapping()
+    @GetMapping("/my-chatrooms")
     @Operation(summary = "내 채팅방 목록 조회")
     public CommonResponse<List<ChatRoomResponseDto>> getChatRooms() {
         List<ChatRoomResponseDto> chatRoomResponseDtos = chatRoomService.getChatRoomsByUser();

--- a/src/main/java/com/hotsix/server/message/controller/SseController.java
+++ b/src/main/java/com/hotsix/server/message/controller/SseController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RestController
-@RequestMapping("/api/sse")
+@RequestMapping("/api/v1/sse")
 @RequiredArgsConstructor
 @Tag(name = "SseController", description = "SSE 컨트롤러")
 public class SseController {

--- a/src/main/java/com/hotsix/server/proposal/controller/ProposalController.java
+++ b/src/main/java/com/hotsix/server/proposal/controller/ProposalController.java
@@ -6,11 +6,13 @@ import com.hotsix.server.proposal.dto.ProposalRequestDto;
 import com.hotsix.server.proposal.dto.ProposalResponseDto;
 import com.hotsix.server.proposal.dto.ProposalStatusRequestBody;
 import com.hotsix.server.proposal.entity.ProposalStatus;
+import com.hotsix.server.proposal.entity.proposalPorfolio.ProposalFile;
 import com.hotsix.server.proposal.service.ProposalService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -42,18 +44,18 @@ public class ProposalController {
         );
     }
 
-    @PostMapping/*(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)*/
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "제안서 작성")
     public CommonResponse<ProposalResponseDto> createProposal(
-            @Valid @RequestBody ProposalRequestDto proposalRequestDto
-            //@RequestPart(value = "files", required = false) List<ProposalFile> files
+            @Valid @RequestBody ProposalRequestDto proposalRequestDto,
+            @RequestPart(value = "files", required = false) List<ProposalFile> files
     ){
 
         ProposalResponseDto proposalResponseDto = proposalService.create(
                 proposalRequestDto.projectId(),
                 proposalRequestDto.description(),
                 proposalRequestDto.proposedAmount(),
-                //files,
+                files,
                 ProposalStatus.SUBMITTED
         );
 
@@ -76,7 +78,7 @@ public class ProposalController {
             @PathVariable long proposalId,
             @Valid @RequestBody ProposalRequestBody requestBody
     ){
-        proposalService.update(proposalId, requestBody.description(), requestBody.proposedAmount()/*, requestBody.portfolioFiles()*/);
+        proposalService.update(proposalId, requestBody.description(), requestBody.proposedAmount(), requestBody.portfolioFiles());
 
         return CommonResponse.success("%d번 제안서가 수정되었습니다.".formatted(proposalId));
     }

--- a/src/main/java/com/hotsix/server/proposal/controller/ProposalController.java
+++ b/src/main/java/com/hotsix/server/proposal/controller/ProposalController.java
@@ -6,7 +6,6 @@ import com.hotsix.server.proposal.dto.ProposalRequestDto;
 import com.hotsix.server.proposal.dto.ProposalResponseDto;
 import com.hotsix.server.proposal.dto.ProposalStatusRequestBody;
 import com.hotsix.server.proposal.entity.ProposalStatus;
-import com.hotsix.server.proposal.entity.proposalPorfolio.ProposalFile;
 import com.hotsix.server.proposal.service.ProposalService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -14,6 +13,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -47,8 +47,8 @@ public class ProposalController {
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "제안서 작성")
     public CommonResponse<ProposalResponseDto> createProposal(
-            @Valid @RequestBody ProposalRequestDto proposalRequestDto,
-            @RequestPart(value = "files", required = false) List<ProposalFile> files
+            @Valid @RequestPart("proposal") ProposalRequestDto proposalRequestDto,
+            @RequestPart(value = "files", required = false) List<MultipartFile> files //ProposalFile DTO로 변경해야함
     ){
 
         ProposalResponseDto proposalResponseDto = proposalService.create(
@@ -66,10 +66,11 @@ public class ProposalController {
 
     @DeleteMapping("/{proposalId}")
     @Operation(summary = "제안서 삭제")
-    public CommonResponse<ProposalResponseDto> deleteProposal(
+    public CommonResponse<String> deleteProposal(
             @PathVariable long proposalId
     ){
-        return CommonResponse.success(proposalService.delete(proposalId));
+        proposalService.delete(proposalId);
+        return CommonResponse.success("%d번 제안서가 삭제되었습니다.".formatted(proposalId));
     }
 
     @PatchMapping("/{proposalId}")

--- a/src/main/java/com/hotsix/server/proposal/dto/ProposalFileResponseDto.java
+++ b/src/main/java/com/hotsix/server/proposal/dto/ProposalFileResponseDto.java
@@ -1,0 +1,19 @@
+package com.hotsix.server.proposal.dto;
+
+import com.hotsix.server.proposal.entity.ProposalFile;
+
+public record ProposalFileResponseDto(
+        Long id,
+        String fileName,
+        String filePath,
+        String fileType
+) {
+    public ProposalFileResponseDto(ProposalFile file) {
+        this(
+                file.getProposalFileId(),
+                file.getFileName(),
+                file.getFilePath(),
+                file.getFileType()
+        );
+    }
+}

--- a/src/main/java/com/hotsix/server/proposal/dto/ProposalRequestBody.java
+++ b/src/main/java/com/hotsix/server/proposal/dto/ProposalRequestBody.java
@@ -1,15 +1,18 @@
 package com.hotsix.server.proposal.dto;
 
+import com.hotsix.server.proposal.entity.proposalPorfolio.ProposalFile;
 import jakarta.persistence.Lob;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
 
 public record ProposalRequestBody (
         @NotBlank
         @Lob
         String description,
         @NotNull
-        Integer proposedAmount
-        //List<ProposalFile> portfolioFiles
+        Integer proposedAmount,
+        List<ProposalFile> portfolioFiles
 ){
 }

--- a/src/main/java/com/hotsix/server/proposal/dto/ProposalRequestBody.java
+++ b/src/main/java/com/hotsix/server/proposal/dto/ProposalRequestBody.java
@@ -1,6 +1,6 @@
 package com.hotsix.server.proposal.dto;
 
-import com.hotsix.server.proposal.entity.proposalPorfolio.ProposalFile;
+import com.hotsix.server.proposal.entity.ProposalFile;
 import jakarta.persistence.Lob;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/com/hotsix/server/proposal/dto/ProposalResponseDto.java
+++ b/src/main/java/com/hotsix/server/proposal/dto/ProposalResponseDto.java
@@ -2,7 +2,6 @@ package com.hotsix.server.proposal.dto;
 
 import com.hotsix.server.proposal.entity.Proposal;
 import com.hotsix.server.proposal.entity.ProposalStatus;
-import com.hotsix.server.proposal.entity.proposalPorfolio.ProposalFile;
 import org.springframework.lang.NonNull;
 
 import java.time.LocalDateTime;
@@ -16,7 +15,7 @@ public record ProposalResponseDto (
         @NonNull Long senderId,
         @NonNull String description,
         @NonNull Integer proposedAmount,
-        List<ProposalFile> portfolioFiles,
+        List<ProposalFileResponseDto> portfolioFiles,
         @NonNull ProposalStatus proposalStatus
 ){
     public ProposalResponseDto(Proposal proposal){
@@ -28,7 +27,9 @@ public record ProposalResponseDto (
                 proposal.getSender().getUserId(),
                 proposal.getDescription(),
                 proposal.getProposedAmount(),
-                proposal.getPortfolioFiles(),
+                proposal.getPortfolioFiles().stream()
+                        .map(ProposalFileResponseDto::new)
+                        .toList(),
                 proposal.getProposalStatus()
         );
     }

--- a/src/main/java/com/hotsix/server/proposal/dto/ProposalResponseDto.java
+++ b/src/main/java/com/hotsix/server/proposal/dto/ProposalResponseDto.java
@@ -2,9 +2,11 @@ package com.hotsix.server.proposal.dto;
 
 import com.hotsix.server.proposal.entity.Proposal;
 import com.hotsix.server.proposal.entity.ProposalStatus;
+import com.hotsix.server.proposal.entity.proposalPorfolio.ProposalFile;
 import org.springframework.lang.NonNull;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record ProposalResponseDto (
         Long proposalId,
@@ -14,7 +16,7 @@ public record ProposalResponseDto (
         @NonNull Long senderId,
         @NonNull String description,
         @NonNull Integer proposedAmount,
-        //List<ProposalFile> portfolioFiles,
+        List<ProposalFile> portfolioFiles,
         @NonNull ProposalStatus proposalStatus
 ){
     public ProposalResponseDto(Proposal proposal){
@@ -26,7 +28,7 @@ public record ProposalResponseDto (
                 proposal.getSender().getUserId(),
                 proposal.getDescription(),
                 proposal.getProposedAmount(),
-                //proposal.getPortfolioFiles(),
+                proposal.getPortfolioFiles(),
                 proposal.getProposalStatus()
         );
     }

--- a/src/main/java/com/hotsix/server/proposal/entity/Proposal.java
+++ b/src/main/java/com/hotsix/server/proposal/entity/Proposal.java
@@ -3,10 +3,14 @@ package com.hotsix.server.proposal.entity;
 import com.hotsix.server.global.entity.BaseEntity;
 import com.hotsix.server.global.exception.ApplicationException;
 import com.hotsix.server.project.entity.Project;
+import com.hotsix.server.proposal.entity.proposalPorfolio.ProposalFile;
 import com.hotsix.server.proposal.exception.ProposalErrorCase;
 import com.hotsix.server.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -33,9 +37,9 @@ public class Proposal extends BaseEntity {
 
     private Integer proposedAmount;
 
-//    @Builder.Default
-//    @OneToMany(mappedBy = "proposal", cascade = CascadeType.ALL, orphanRemoval = true)
-//    private List<ProposalFile> portfolioFiles = new ArrayList<>();
+    @Builder.Default
+    @OneToMany(mappedBy = "proposal", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ProposalFile> portfolioFiles = new ArrayList<>();
 
     @Enumerated(EnumType.STRING)
     private ProposalStatus proposalStatus; // DRAFT, SUBMITTED, ACCEPTED, REJECTED
@@ -52,10 +56,10 @@ public class Proposal extends BaseEntity {
         }
     }
 
-    public void modify(String description, Integer proposedAmount/*, List<ProposalFile> proposalFiles*/) {
+    public void modify(String description, Integer proposedAmount, List<ProposalFile> proposalFiles) {
         this.description = description;
         this.proposedAmount = proposedAmount;
-        //this.portfolioFiles = proposalFiles;
+        this.portfolioFiles = proposalFiles;
     }
 
     public void modify(ProposalStatus proposalStatus) {

--- a/src/main/java/com/hotsix/server/proposal/entity/Proposal.java
+++ b/src/main/java/com/hotsix/server/proposal/entity/Proposal.java
@@ -3,7 +3,6 @@ package com.hotsix.server.proposal.entity;
 import com.hotsix.server.global.entity.BaseEntity;
 import com.hotsix.server.global.exception.ApplicationException;
 import com.hotsix.server.project.entity.Project;
-import com.hotsix.server.proposal.entity.proposalPorfolio.ProposalFile;
 import com.hotsix.server.proposal.exception.ProposalErrorCase;
 import com.hotsix.server.user.entity.User;
 import jakarta.persistence.*;
@@ -64,5 +63,10 @@ public class Proposal extends BaseEntity {
 
     public void modify(ProposalStatus proposalStatus) {
         this.proposalStatus = proposalStatus;
+    }
+
+    public void addFiles(List<ProposalFile> files) {
+        this.portfolioFiles.addAll(files);
+        files.forEach(file -> file.setProposal(this));
     }
 }

--- a/src/main/java/com/hotsix/server/proposal/entity/ProposalFile.java
+++ b/src/main/java/com/hotsix/server/proposal/entity/ProposalFile.java
@@ -1,6 +1,5 @@
-package com.hotsix.server.proposal.entity.proposalPorfolio;
+package com.hotsix.server.proposal.entity;
 
-import com.hotsix.server.proposal.entity.Proposal;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -20,8 +19,10 @@ public class ProposalFile {
     private String filePath;     // 저장된 경로 or URL
     private String fileType;     // MIME 타입 (pdf, png, etc)
 
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "proposal_id")
     private Proposal proposal;
+
 }
 

--- a/src/main/java/com/hotsix/server/proposal/entity/proposalPorfolio/ProposalFile.java
+++ b/src/main/java/com/hotsix/server/proposal/entity/proposalPorfolio/ProposalFile.java
@@ -1,27 +1,27 @@
-//package com.hotsix.server.proposal.entity.proposalPorfolio;
-//
-//import com.hotsix.server.proposal.entity.Proposal;
-//import jakarta.persistence.*;
-//import lombok.*;
-//
-//@Entity
-//@Getter
-//@NoArgsConstructor(access = AccessLevel.PROTECTED)
-//@AllArgsConstructor
-//@Builder
-//@Table(name = "proposal_files")
-//public class ProposalFile {
-//
-//    @Id
-//    @GeneratedValue(strategy = GenerationType.IDENTITY)
-//    private Long proposalFileId;
-//
-//    private String fileName;     // 원본 파일명
-//    private String filePath;     // 저장된 경로 or URL
-//    private String fileType;     // MIME 타입 (pdf, png, etc)
-//
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "proposal_id")
-//    private Proposal proposal;
-//}
+package com.hotsix.server.proposal.entity.proposalPorfolio;
+
+import com.hotsix.server.proposal.entity.Proposal;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "proposal_files")
+public class ProposalFile {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long proposalFileId;
+
+    private String fileName;     // 원본 파일명
+    private String filePath;     // 저장된 경로 or URL
+    private String fileType;     // MIME 타입 (pdf, png, etc)
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "proposal_id")
+    private Proposal proposal;
+}
 

--- a/src/main/java/com/hotsix/server/proposal/service/ProposalService.java
+++ b/src/main/java/com/hotsix/server/proposal/service/ProposalService.java
@@ -7,6 +7,7 @@ import com.hotsix.server.project.service.ProjectService;
 import com.hotsix.server.proposal.dto.ProposalResponseDto;
 import com.hotsix.server.proposal.entity.Proposal;
 import com.hotsix.server.proposal.entity.ProposalStatus;
+import com.hotsix.server.proposal.entity.proposalPorfolio.ProposalFile;
 import com.hotsix.server.proposal.exception.ProposalErrorCase;
 import com.hotsix.server.proposal.repository.ProposalRepository;
 import com.hotsix.server.user.entity.User;
@@ -31,16 +32,16 @@ public class ProposalService {
     }
 
     @Transactional(readOnly = true)
-    public ProposalResponseDto findById(long id) {
+    public ProposalResponseDto findById(long proposalId) {
 
-        Proposal proposal = proposalRepository.findById(id)
+        Proposal proposal = proposalRepository.findById(proposalId)
                 .orElseThrow(() -> new ApplicationException(ProposalErrorCase.PROPOSAL_NOT_FOUND));
 
         return new ProposalResponseDto(proposal);
     }
 
     @Transactional
-    public ProposalResponseDto create(Long projectId, String description, Integer proposedAmount, /*List<ProposalFile> proposalFiles,*/ ProposalStatus proposalStatus) {
+    public ProposalResponseDto create(Long projectId, String description, Integer proposedAmount, List<ProposalFile> proposalFiles, ProposalStatus proposalStatus) {
 
         Project project = projectService.findById(projectId);
 
@@ -51,7 +52,7 @@ public class ProposalService {
                 .sender(actor)
                 .description(description)
                 .proposedAmount(proposedAmount)
-                //.portfolioFiles(proposalFiles)
+                .portfolioFiles(proposalFiles)
                 .proposalStatus(proposalStatus)
                 .build();
 
@@ -59,8 +60,8 @@ public class ProposalService {
     }
 
     @Transactional
-    public ProposalResponseDto delete(long id) {
-        Proposal proposal = proposalRepository.findById(id)
+    public ProposalResponseDto delete(long proposalId) {
+        Proposal proposal = proposalRepository.findById(proposalId)
                 .orElseThrow(() -> new ApplicationException(ProposalErrorCase.PROPOSAL_NOT_FOUND));
 
         User actor = rq.getUser();
@@ -74,22 +75,23 @@ public class ProposalService {
     }
 
     @Transactional
-    public void update(long id, String description, Integer proposedAmount/*, List<ProposalFile> proposalFiles*/) {
-        Proposal proposal = proposalRepository.findById(id)
+    public void update(long proposalId, String description, Integer proposedAmount, List<ProposalFile> proposalFiles) {
+        Proposal proposal = proposalRepository.findById(proposalId)
                 .orElseThrow(() -> new ApplicationException(ProposalErrorCase.PROPOSAL_NOT_FOUND));
         User actor = rq.getUser();
         proposal.checkCanModify(actor);
-        proposal.modify(description, proposedAmount/*, proposalFiles*/);
+        proposal.modify(description, proposedAmount, proposalFiles);
     }
 
     @Transactional
-    public void update(long id, ProposalStatus proposalStatus) {
-        Proposal proposal = proposalRepository.findById(id)
+    public void update(long proposalId, ProposalStatus proposalStatus) {
+        Proposal proposal = proposalRepository.findById(proposalId)
                 .orElseThrow(() -> new ApplicationException(ProposalErrorCase.PROPOSAL_NOT_FOUND));
 
         User actor = rq.getUser();
 
         // actor 검증 로직 구현 필요
+
 
         proposal.modify(proposalStatus);
     }

--- a/src/main/java/com/hotsix/server/proposal/service/ProposalService.java
+++ b/src/main/java/com/hotsix/server/proposal/service/ProposalService.java
@@ -89,7 +89,6 @@ public class ProposalService {
 
         User actor = rq.getUser();
         proposal.checkCanDelete(actor);
-        ProposalResponseDto responseDto = new ProposalResponseDto(proposal);
         proposalRepository.delete(proposal);
     }
 

--- a/src/main/java/com/hotsix/server/proposal/service/ProposalService.java
+++ b/src/main/java/com/hotsix/server/proposal/service/ProposalService.java
@@ -89,6 +89,16 @@ public class ProposalService {
 
         User actor = rq.getUser();
         proposal.checkCanDelete(actor);
+
+        // ✅ 실제 파일 삭제
+        for (ProposalFile file : proposal.getPortfolioFiles()) {
+            try {
+                Files.deleteIfExists(Paths.get(file.getFilePath()));
+            } catch (IOException e) {
+                throw new RuntimeException("파일 삭제 실패: ", e);
+            }
+        }
+
         proposalRepository.delete(proposal);
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #12, #38 

## 📝 작업 내용

> 제안서 등록시 파일 업로드 기능 구현했습니다.
> Swagger의 경우 request body가 form-data인 경우 JSON을 정상적으로 읽지 못하여 Postman으로 테스트 하였습니다.
> 임시로 업로드한 파일을 로컬(/uploads/proposals/)에 업로드하도록 구현하였습니다. 추후에 수정해야 합니다. 

## 🖼️ 스크린샷 (선택)

<img width="844" height="674" alt="image" src="https://github.com/user-attachments/assets/09310377-ee93-4001-ad9b-f8386c0d2d07" />

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 제안 생성 시 파일 업로드(multipart) 지원 및 파일 저장/메타데이터 관리.
  - 제안 조회 응답에 포트폴리오 파일 목록 포함.

- Refactor
  - 제안 삭제 API가 확인 메시지를 반환하도록 변경.
  - SSE 엔드포인트 프리픽스가 /api/v1/sse 로 버저닝.
  - 내 채팅방 조회 엔드포인트 경로를 명시적 라우트로 변경.
  - 제안 관련 API 파라미터와 흐름 정리(파일 연계 업데이트 포함).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->